### PR TITLE
Python 3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - "2.6"
   - "2.7"
+  - "3.6"
   - "pypy"
 install:
   - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: python
-python:
-  - "2.6"
-  - "2.7"
-  - "3.6"
-  - "pypy"
+matrix:
+  include:
+    - python: 2.6
+      env: TOXENV=py26
+    - python: 3.6
+      env: TOXENV=py36
+    - python: pypy
+      env: TOXENV=pypy
 install:
-  - python setup.py install
-  - pip install -r test_requirements.txt
+  - pip install tox
 script:
-  - python setup.py test
+  - tox -e $TOXENV

--- a/fixtures/analytics_autoselects.yaml
+++ b/fixtures/analytics_autoselects.yaml
@@ -1,17 +1,13 @@
-- request: !!python/object:vcr.request.Request
+interactions:
+- request:
     body: ''
-    headers: !!python/object/apply:__builtin__.frozenset
-    - - !!python/tuple [User-Agent, Swiftype-Python/1.0.0]
-      - !!python/tuple [Content-Type, application/json]
-    host: localhost
+    headers:
+      Content-Type: [application/json]
+      User-Agent: [Swiftype-Python/1.0.0]
     method: GET
-    path: /api/v1/engines/api-test/analytics/autoselects.json?auth_token=a-test-api-key
-    port: 3000
-    protocol: http
+    uri: http://localhost:3000/api/v1/engines/api-test/analytics/autoselects.json?auth_token=a-test-api-key
   response:
     body: {string: '[["2014-01-06",0],["2014-01-05",0],["2014-01-04",0],["2014-01-03",0],["2014-01-02",0],["2014-01-01",0],["2013-12-31",0],["2013-12-30",0],["2013-12-29",0],["2013-12-28",0],["2013-12-27",0],["2013-12-26",0],["2013-12-25",0],["2013-12-24",0],["2013-12-23",0]]'}
-    headers: {cache-control: 'max-age=0, private, must-revalidate', connection: close,
-      content-type: application/json; charset=utf-8, etag: '"d4e02fbdbba3a819f576e328f1a08201"',
-      server: thin 1.5.0 codename Knife, x-request-id: e9796df35b44951f138f20e31a1ef70e,
-      x-runtime: '0.017000', x-ua-compatible: IE=Edge}
+    headers: {}
     status: {code: 200, message: OK}
+version: 1

--- a/fixtures/analytics_autoselects_pagination.yaml
+++ b/fixtures/analytics_autoselects_pagination.yaml
@@ -1,17 +1,13 @@
-- request: !!python/object:vcr.request.Request
+interactions:
+- request:
     body: ''
-    headers: !!python/object/apply:__builtin__.frozenset
-    - - !!python/tuple [User-Agent, Swiftype-Python/1.0.0]
-      - !!python/tuple [Content-Type, application/json]
-    host: localhost
+    headers:
+      Content-Type: [application/json]
+      User-Agent: [Swiftype-Python/1.0.0]
     method: GET
-    path: /api/v1/engines/api-test/analytics/autoselects.json?auth_token=a-test-api-key&start_date=2013-12-31&end_date=2014-01-01
-    port: 3000
-    protocol: http
+    uri: http://localhost:3000/api/v1/engines/api-test/analytics/autoselects.json?auth_token=a-test-api-key&start_date=2013-12-31&end_date=2014-01-01
   response:
     body: {string: '[["2014-01-01",0],["2013-12-31",0]]'}
-    headers: {cache-control: 'max-age=0, private, must-revalidate', connection: close,
-      content-type: application/json; charset=utf-8, etag: '"0fcfc6befc63f00afcd764be995a341a"',
-      server: thin 1.5.0 codename Knife, x-request-id: f4eec152cb66eec412b1b501ed65a650,
-      x-runtime: '0.018431', x-ua-compatible: IE=Edge}
+    headers: {}
     status: {code: 200, message: OK}
+version: 1

--- a/fixtures/analytics_searches.yaml
+++ b/fixtures/analytics_searches.yaml
@@ -1,17 +1,13 @@
-- request: !!python/object:vcr.request.Request
+interactions:
+- request:
     body: ''
-    headers: !!python/object/apply:__builtin__.frozenset
-    - - !!python/tuple [User-Agent, Swiftype-Python/1.0.0]
-      - !!python/tuple [Content-Type, application/json]
-    host: localhost
+    headers:
+      Content-Type: [application/json]
+      User-Agent: [Swiftype-Python/1.0.0]
     method: GET
-    path: /api/v1/engines/api-test/analytics/searches.json?auth_token=a-test-api-key
-    port: 3000
-    protocol: http
+    uri: http://localhost:3000/api/v1/engines/api-test/analytics/searches.json?auth_token=a-test-api-key
   response:
     body: {string: '[["2014-01-06",0],["2014-01-05",0],["2014-01-04",0],["2014-01-03",0],["2014-01-02",0],["2014-01-01",0],["2013-12-31",0],["2013-12-30",0],["2013-12-29",0],["2013-12-28",0],["2013-12-27",0],["2013-12-26",0],["2013-12-25",0],["2013-12-24",0],["2013-12-23",0]]'}
-    headers: {cache-control: 'max-age=0, private, must-revalidate', connection: close,
-      content-type: application/json; charset=utf-8, etag: '"d4e02fbdbba3a819f576e328f1a08201"',
-      server: thin 1.5.0 codename Knife, x-request-id: 135751460e794fb220b4219bc1ce3ad0,
-      x-runtime: '0.047857', x-ua-compatible: IE=Edge}
+    headers: {}
     status: {code: 200, message: OK}
+version: 1

--- a/fixtures/analytics_searches_pagination.yaml
+++ b/fixtures/analytics_searches_pagination.yaml
@@ -1,17 +1,13 @@
-- request: !!python/object:vcr.request.Request
+interactions:
+- request:
     body: ''
-    headers: !!python/object/apply:__builtin__.frozenset
-    - - !!python/tuple [User-Agent, Swiftype-Python/1.0.0]
-      - !!python/tuple [Content-Type, application/json]
-    host: localhost
+    headers:
+      Content-Type: [application/json]
+      User-Agent: [Swiftype-Python/1.0.0]
     method: GET
-    path: /api/v1/engines/api-test/analytics/searches.json?auth_token=a-test-api-key&start_date=2013-12-31&end_date=2014-01-01
-    port: 3000
-    protocol: http
+    uri: http://localhost:3000/api/v1/engines/api-test/analytics/searches.json?auth_token=a-test-api-key&start_date=2013-12-31&end_date=2014-01-01
   response:
     body: {string: '[["2014-01-01",0],["2013-12-31",0]]'}
-    headers: {cache-control: 'max-age=0, private, must-revalidate', connection: close,
-      content-type: application/json; charset=utf-8, etag: '"0fcfc6befc63f00afcd764be995a341a"',
-      server: thin 1.5.0 codename Knife, x-request-id: b39c5688e2b0e601eb4a3199eaecab58,
-      x-runtime: '0.018621', x-ua-compatible: IE=Edge}
+    headers: {}
     status: {code: 200, message: OK}
+version: 1

--- a/fixtures/analytics_top_no_result_queries.yaml
+++ b/fixtures/analytics_top_no_result_queries.yaml
@@ -1,17 +1,13 @@
-- request: !!python/object:vcr.request.Request
+interactions:
+- request:
     body: ''
-    headers: !!python/object/apply:__builtin__.frozenset
-    - - !!python/tuple [User-Agent, Swiftype-Python/1.0.0]
-      - !!python/tuple [Content-Type, application/json]
-    host: localhost
+    headers:
+      Content-Type: [application/json]
+      User-Agent: [Swiftype-Python/1.0.0]
     method: GET
-    path: /api/v1/engines/api-test/analytics/top_no_result_queries_in_range.json?auth_token=a-test-api-key
-    port: 3000
-    protocol: http
+    uri: http://localhost:3000/api/v1/engines/api-test/analytics/top_no_result_queries_in_range.json?auth_token=a-test-api-key
   response:
     body: {string: '[["foo",2],["bar",1]]'}
-    headers: {cache-control: 'max-age=0, private, must-revalidate', connection: close,
-      content-type: application/json; charset=utf-8, etag: '"d751713988987e9331980363e24189ce"',
-      server: thin 1.5.0 codename Knife, x-request-id: 4ba743d24f32e8bf5f2c24bc091ae320,
-      x-runtime: '0.022363', x-ua-compatible: IE=Edge}
+    headers: {}
     status: {code: 200, message: OK}
+version: 1

--- a/fixtures/analytics_top_no_result_queries_with_dates.yaml
+++ b/fixtures/analytics_top_no_result_queries_with_dates.yaml
@@ -1,17 +1,13 @@
-- request: !!python/object:vcr.request.Request
+interactions:
+- request:
     body: ''
-    headers: !!python/object/apply:__builtin__.frozenset
-    - - !!python/tuple [User-Agent, Swiftype-Python/1.0.0]
-      - !!python/tuple [Content-Type, application/json]
-    host: localhost
+    headers:
+      Content-Type: [application/json]
+      User-Agent: [Swiftype-Python/1.0.0]
     method: GET
-    path: /api/v1/engines/api-test/analytics/top_no_result_queries_in_range.json?auth_token=a-test-api-key&start_date=2013-12-31&end_date=2014-01-01
-    port: 3000
-    protocol: http
+    uri: http://localhost:3000/api/v1/engines/api-test/analytics/top_no_result_queries_in_range.json?auth_token=a-test-api-key&start_date=2013-12-31&end_date=2014-01-01
   response:
     body: {string: '[["foo",2],["bar",1]]'}
-    headers: {cache-control: 'max-age=0, private, must-revalidate', connection: close,
-      content-type: application/json; charset=utf-8, etag: '"d751713988987e9331980363e24189ce"',
-      server: thin 1.5.0 codename Knife, x-request-id: 404ac03a546269759b387b3d20558581,
-      x-runtime: '0.018528', x-ua-compatible: IE=Edge}
+    headers: {}
     status: {code: 200, message: OK}
+version: 1

--- a/fixtures/analytics_top_queries.yaml
+++ b/fixtures/analytics_top_queries.yaml
@@ -1,17 +1,13 @@
-- request: !!python/object:vcr.request.Request
+interactions:
+- request:
     body: ''
-    headers: !!python/object/apply:__builtin__.frozenset
-    - - !!python/tuple [User-Agent, Swiftype-Python/1.0.0]
-      - !!python/tuple [Content-Type, application/json]
-    host: localhost
+    headers:
+      Content-Type: [application/json]
+      User-Agent: [Swiftype-Python/1.0.0]
     method: GET
-    path: /api/v1/engines/api-test/analytics/top_queries.json?auth_token=a-test-api-key
-    port: 3000
-    protocol: http
+    uri: http://localhost:3000/api/v1/engines/api-test/analytics/top_queries.json?auth_token=a-test-api-key
   response:
     body: {string: '[["dostoyevsky",2],["gatsby",1]]'}
-    headers: {cache-control: 'max-age=0, private, must-revalidate', connection: close,
-      content-type: application/json; charset=utf-8, etag: '"d751713988987e9331980363e24189ce"',
-      server: thin 1.5.0 codename Knife, x-request-id: aad1a371b3b319c586ba9f1e47512d0e,
-      x-runtime: '0.148543', x-ua-compatible: IE=Edge}
+    headers: {}
     status: {code: 200, message: OK}
+version: 1

--- a/fixtures/analytics_top_queries_in_range.yaml
+++ b/fixtures/analytics_top_queries_in_range.yaml
@@ -1,17 +1,13 @@
-- request: !!python/object:vcr.request.Request
+interactions:
+- request:
     body: ''
-    headers: !!python/object/apply:__builtin__.frozenset
-    - - !!python/tuple [User-Agent, Swiftype-Python/1.0.0]
-      - !!python/tuple [Content-Type, application/json]
-    host: localhost
+    headers:
+      Content-Type: [application/json]
+      User-Agent: [Swiftype-Python/1.0.0]
     method: GET
-    path: /api/v1/engines/api-test/analytics/top_queries_in_range.json?auth_token=a-test-api-key&start_date=2013-12-31&end_date=2014-01-01
-    port: 3000
-    protocol: http
+    uri: http://localhost:3000/api/v1/engines/api-test/analytics/top_queries_in_range.json?auth_token=a-test-api-key&start_date=2013-12-31&end_date=2014-01-01
   response:
     body: {string: '[["dostoyevsky",2],["gatsby",1]]'}
-    headers: {cache-control: 'max-age=0, private, must-revalidate', connection: close,
-      content-type: application/json; charset=utf-8, etag: '"d751713988987e9331980363e24189ce"',
-      server: thin 1.5.0 codename Knife, x-request-id: 235629bc196d3670614a343c86968f37,
-      x-runtime: '0.015943', x-ua-compatible: IE=Edge}
+    headers: {}
     status: {code: 200, message: OK}
+version: 1

--- a/fixtures/analytics_top_queries_pagination.yaml
+++ b/fixtures/analytics_top_queries_pagination.yaml
@@ -1,17 +1,13 @@
-- request: !!python/object:vcr.request.Request
+interactions:
+- request:
     body: ''
-    headers: !!python/object/apply:__builtin__.frozenset
-    - - !!python/tuple [User-Agent, Swiftype-Python/1.0.0]
-      - !!python/tuple [Content-Type, application/json]
-    host: localhost
+    headers:
+      Content-Type: [application/json]
+      User-Agent: [Swiftype-Python/1.0.0]
     method: GET
-    path: /api/v1/engines/api-test/analytics/top_queries.json?per_page=10&auth_token=a-test-api-key&page=2
-    port: 3000
-    protocol: http
+    uri: http://localhost:3000/api/v1/engines/api-test/analytics/top_queries.json?per_page=10&auth_token=a-test-api-key&page=2
   response:
     body: {string: '[["dostoyevsky",2],["gatsby",1]]'}
-    headers: {cache-control: 'max-age=0, private, must-revalidate', connection: close,
-      content-type: application/json; charset=utf-8, etag: '"d751713988987e9331980363e24189ce"',
-      server: thin 1.5.0 codename Knife, x-request-id: 038ab193a41ca1d0f67e7dd676a5192d,
-      x-runtime: '0.022563', x-ua-compatible: IE=Edge}
+    headers: {}
     status: {code: 200, message: OK}
+version: 1

--- a/fixtures/crawl_domain.yaml
+++ b/fixtures/crawl_domain.yaml
@@ -1,17 +1,13 @@
-- request: !!python/object:vcr.request.Request
+interactions:
+- request:
     body: '{"url": "http://crawler-demo-site.herokuapp.com/2012/01/01/first-post.html"}'
-    headers: !!python/object/apply:__builtin__.frozenset
-    - - !!python/tuple [User-Agent, Swiftype-Python/1.0.0]
-      - !!python/tuple [Content-Type, application/json]
-    host: localhost
+    headers:
+      Content-Type: [application/json]
+      User-Agent: [Swiftype-Python/1.0.0]
     method: PUT
-    path: /api/v1/engines/crawler-demo/domains/52c754fb3ae7406fd3000001/crawl_url.json?auth_token=a-test-api-key
-    port: 3000
-    protocol: http
+    uri: http://localhost:3000/api/v1/engines/crawler-demo/domains/52c754fb3ae7406fd3000001/crawl_url.json?auth_token=a-test-api-key
   response:
     body: {string: '{"external_id":"9508ace2e1ba669854eb49fbe9429952ff1a6d4c","url":"http://crawler-demo-site.herokuapp.com/2012/01/01/first-post.html"}'}
-    headers: {cache-control: 'max-age=0, private, must-revalidate', connection: close,
-      content-type: application/json; charset=utf-8, etag: '"dc3e7df6ad36f807472e018fd1e7baeb"',
-      server: thin 1.5.0 codename Knife, x-request-id: b47b431d9d6c55cbaa30a6daa98ed593,
-      x-runtime: '0.023079', x-ua-compatible: IE=Edge}
+    headers: {}
     status: {code: 200, message: OK}
+version: 1

--- a/fixtures/create_document.yaml
+++ b/fixtures/create_document.yaml
@@ -1,17 +1,13 @@
-- request: !!python/object:vcr.request.Request
+interactions:
+- request:
     body: '{"document": {"external_id": "doc_id"}}'
-    headers: !!python/object/apply:__builtin__.frozenset
-    - - !!python/tuple [User-Agent, Swiftype-Python/1.0.0]
-      - !!python/tuple [Content-Type, application/json]
-    host: localhost
+    headers:
+      Content-Type: [application/json]
+      User-Agent: [Swiftype-Python/1.0.0]
     method: POST
-    path: /api/v1/engines/api-test/document_types/books/documents.json?auth_token=a-test-api-key
-    port: 3000
-    protocol: http
+    uri: http://localhost:3000/api/v1/engines/api-test/document_types/books/documents.json?auth_token=a-test-api-key
   response:
     body: {string: '{"external_id":"doc_id","engine_id":"52c73e443ae7403ec900001e","document_type_id":"52c742b63ae7401cb6000004","id":"52cb1f823ae7403ec900003e","_id":"52cb1f823ae7403ec900003e","updated_at":"2014-01-06T21:26:26Z"}'}
-    headers: {cache-control: 'max-age=0, private, must-revalidate', connection: close,
-      content-type: application/json; charset=utf-8, etag: '"72a0014aa4dc2dff2424d2e4b24a58f5"',
-      server: thin 1.5.0 codename Knife, x-request-id: 79febce38457cf0ea6d796dc98572ebd,
-      x-runtime: '0.174664', x-ua-compatible: IE=Edge}
+    headers: {}
     status: {code: 200, message: OK}
+version: 1

--- a/fixtures/create_document_type.yaml
+++ b/fixtures/create_document_type.yaml
@@ -1,17 +1,13 @@
-- request: !!python/object:vcr.request.Request
+interactions:
+- request:
     body: '{"document_type": {"name": "videos"}}'
-    headers: !!python/object/apply:__builtin__.frozenset
-    - - !!python/tuple [User-Agent, Swiftype-Python/1.0.0]
-      - !!python/tuple [Content-Type, application/json]
-    host: localhost
+    headers:
+      Content-Type: [application/json]
+      User-Agent: [Swiftype-Python/1.0.0]
     method: POST
-    path: /api/v1/engines/api-test/document_types.json?auth_token=a-test-api-key
-    port: 3000
-    protocol: http
+    uri: http://localhost:3000/api/v1/engines/api-test/document_types.json?auth_token=a-test-api-key
   response:
     body: {string: '{"id":"52cb1ee93ae7403ec900003c","name":"videos","slug":"videos","engine_id":"52c73e443ae7403ec900001e","updated_at":"2014-01-06T21:23:53Z","document_count":0,"field_mapping":{}}'}
-    headers: {cache-control: 'max-age=0, private, must-revalidate', connection: close,
-      content-type: application/json; charset=utf-8, etag: '"b2cc3e37efc8719231662f2ff5e0798e"',
-      server: thin 1.5.0 codename Knife, x-request-id: 56e9d5c0313379bbd8f41b469238605c,
-      x-runtime: '0.190310', x-ua-compatible: IE=Edge}
+    headers: {}
     status: {code: 200, message: OK}
+version: 1

--- a/fixtures/create_documents.yaml
+++ b/fixtures/create_documents.yaml
@@ -1,17 +1,13 @@
-- request: !!python/object:vcr.request.Request
+interactions:
+- request:
     body: '{"documents": [{"external_id": "doc_id1"}, {"external_id": "doc_id2"}]}'
-    headers: !!python/object/apply:__builtin__.frozenset
-    - - !!python/tuple [User-Agent, Swiftype-Python/1.0.0]
-      - !!python/tuple [Content-Type, application/json]
-    host: localhost
+    headers:
+      Content-Type: [application/json]
+      User-Agent: [Swiftype-Python/1.0.0]
     method: POST
-    path: /api/v1/engines/api-test/document_types/books/documents/bulk_create.json?auth_token=a-test-api-key
-    port: 3000
-    protocol: http
+    uri: http://localhost:3000/api/v1/engines/api-test/document_types/books/documents/bulk_create.json?auth_token=a-test-api-key
   response:
     body: {string: '[true,true]'}
-    headers: {cache-control: 'max-age=0, private, must-revalidate', connection: close,
-      content-type: application/json; charset=utf-8, etag: '"bb009c6dcb5c622766ad5aa1ea1562d9"',
-      server: thin 1.5.0 codename Knife, x-request-id: 944fbbe5ff7fb8f6100823e924de0341,
-      x-runtime: '0.042476', x-ua-compatible: IE=Edge}
+    headers: {}
     status: {code: 200, message: OK}
+version: 1

--- a/fixtures/create_domain.yaml
+++ b/fixtures/create_domain.yaml
@@ -1,17 +1,13 @@
-- request: !!python/object:vcr.request.Request
+interactions:
+- request:
     body: '{"domain": {"submitted_url": "http://www.example.com"}}'
-    headers: !!python/object/apply:__builtin__.frozenset
-    - - !!python/tuple [User-Agent, Swiftype-Python/1.0.0]
-      - !!python/tuple [Content-Type, application/json]
-    host: localhost
+    headers:
+      Content-Type: [application/json]
+      User-Agent: [Swiftype-Python/1.0.0]
     method: POST
-    path: /api/v1/engines/crawler-demo/domains.json?auth_token=a-test-api-key
-    port: 3000
-    protocol: http
+    uri: http://localhost:3000/api/v1/engines/crawler-demo/domains.json?auth_token=a-test-api-key
   response:
     body: {string: '{"id":"52cb2a8a3ae7403ec9000047","engine_id":"52c74ea83ae7403ec9000032","submitted_url":"http://www.example.com","start_crawl_url":"http://www.example.com/","crawling":false,"document_count":0,"updated_at":"2014-01-06T22:13:30Z"}'}
-    headers: {cache-control: 'max-age=0, private, must-revalidate', connection: close,
-      content-type: application/json; charset=utf-8, etag: '"73faa4e7ede7845f0d79538f7980eef6"',
-      server: thin 1.5.0 codename Knife, x-request-id: 21aad17be648edfa4c4d4d547f84b9d1,
-      x-runtime: '0.832495', x-ua-compatible: IE=Edge}
+    headers: {}
     status: {code: 200, message: OK}
+version: 1

--- a/fixtures/create_or_update_document.yaml
+++ b/fixtures/create_or_update_document.yaml
@@ -1,17 +1,13 @@
-- request: !!python/object:vcr.request.Request
+interactions:
+- request:
     body: '{"document": {"fields": {}, "external_id": "1"}}'
-    headers: !!python/object/apply:__builtin__.frozenset
-    - - !!python/tuple [User-Agent, Swiftype-Python/1.0.0]
-      - !!python/tuple [Content-Type, application/json]
-    host: localhost
+    headers:
+      Content-Type: [application/json]
+      User-Agent: [Swiftype-Python/1.0.0]
     method: POST
-    path: /api/v1/engines/api-test/document_types/books/documents/create_or_update.json?auth_token=a-test-api-key
-    port: 3000
-    protocol: http
+    uri: http://localhost:3000/api/v1/engines/api-test/document_types/books/documents/create_or_update.json?auth_token=a-test-api-key
   response:
     body: {string: '{"external_id":"1","engine_id":"52c73e443ae7403ec900001e","document_type_id":"52c742b63ae7401cb6000004","id":"52c743d73ae7403ec9000024","_id":"52c743d73ae7403ec9000024","updated_at":"2014-01-06T21:27:02Z"}'}
-    headers: {cache-control: 'max-age=0, private, must-revalidate', connection: close,
-      content-type: application/json; charset=utf-8, etag: '"649075907555592ef5c4782ec193e521"',
-      server: thin 1.5.0 codename Knife, x-request-id: 153c8f43b488e477274d0493e2711b16,
-      x-runtime: '0.151915', x-ua-compatible: IE=Edge}
+    headers: {}
     status: {code: 200, message: OK}
+version: 1

--- a/fixtures/create_or_update_documents.yaml
+++ b/fixtures/create_or_update_documents.yaml
@@ -1,17 +1,13 @@
-- request: !!python/object:vcr.request.Request
+interactions:
+- request:
     body: '{"documents": [{"external_id": "1"}, {"external_id": "2"}]}'
-    headers: !!python/object/apply:__builtin__.frozenset
-    - - !!python/tuple [User-Agent, Swiftype-Python/1.0.0]
-      - !!python/tuple [Content-Type, application/json]
-    host: localhost
+    headers:
+      Content-Type: [application/json]
+      User-Agent: [Swiftype-Python/1.0.0]
     method: POST
-    path: /api/v1/engines/api-test/document_types/books/documents/bulk_create_or_update.json?auth_token=a-test-api-key
-    port: 3000
-    protocol: http
+    uri: http://localhost:3000/api/v1/engines/api-test/document_types/books/documents/bulk_create_or_update.json?auth_token=a-test-api-key
   response:
     body: {string: '[true,true]'}
-    headers: {cache-control: 'max-age=0, private, must-revalidate', connection: close,
-      content-type: application/json; charset=utf-8, etag: '"bb009c6dcb5c622766ad5aa1ea1562d9"',
-      server: thin 1.5.0 codename Knife, x-request-id: f00d688280159b50dbe1501c724c9258,
-      x-runtime: '0.040930', x-ua-compatible: IE=Edge}
+    headers: {}
     status: {code: 200, message: OK}
+version: 1

--- a/fixtures/create_or_update_documents_failure.yaml
+++ b/fixtures/create_or_update_documents_failure.yaml
@@ -1,18 +1,14 @@
-- request: !!python/object:vcr.request.Request
+interactions:
+- request:
     body: '{"documents": [{"fields": [{"type": "string", "name": "title"}], "external_id":
       "1"}]}'
-    headers: !!python/object/apply:__builtin__.frozenset
-    - - !!python/tuple [User-Agent, Swiftype-Python/1.1.0]
-      - !!python/tuple [Content-Type, application/json]
-    host: localhost
+    headers:
+      Content-Type: [application/json]
+      User-Agent: [Swiftype-Python/1.1.0]
     method: POST
-    path: /api/v1/engines/api-test/document_types/books/documents/bulk_create_or_update.json?auth_token=a-test-api-key
-    port: 3000
-    protocol: http
+    uri: http://localhost:3000/api/v1/engines/api-test/document_types/books/documents/bulk_create_or_update.json?auth_token=a-test-api-key
   response:
     body: {string: '[false]'}
-    headers: {cache-control: 'max-age=0, private, must-revalidate', connection: close,
-      content-type: application/json; charset=utf-8, etag: '"f9e544f77b7eac7add281ef28ca5559f"',
-      server: thin 1.5.0 codename Knife, x-request-id: cb1c48ce2c3e88f890261ff3a53469b2,
-      x-runtime: '0.024775', x-ua-compatible: IE=Edge}
+    headers: {}
     status: {code: 200, message: OK}
+version: 1

--- a/fixtures/create_or_update_documents_verbose.yaml
+++ b/fixtures/create_or_update_documents_verbose.yaml
@@ -1,17 +1,13 @@
-- request: !!python/object:vcr.request.Request
+interactions:
+- request:
     body: '{"documents": [{"external_id": "1"}, {"external_id": "2"}]}'
-    headers: !!python/object/apply:__builtin__.frozenset
-    - - !!python/tuple [User-Agent, Swiftype-Python/1.1.0]
-      - !!python/tuple [Content-Type, application/json]
-    host: localhost
+    headers:
+      Content-Type: [application/json]
+      User-Agent: [Swiftype-Python/1.1.0]
     method: POST
-    path: /api/v1/engines/api-test/document_types/books/documents/bulk_create_or_update_verbose.json?auth_token=a-test-api-key
-    port: 3000
-    protocol: http
+    uri: http://localhost:3000/api/v1/engines/api-test/document_types/books/documents/bulk_create_or_update_verbose.json?auth_token=a-test-api-key
   response:
     body: {string: '[true,true]'}
-    headers: {cache-control: 'max-age=0, private, must-revalidate', connection: close,
-      content-type: application/json; charset=utf-8, etag: '"bb009c6dcb5c622766ad5aa1ea1562d9"',
-      server: thin 1.5.0 codename Knife, x-request-id: 8253f4aa4737371ea7e64c5ad42d3056,
-      x-runtime: '0.041665', x-ua-compatible: IE=Edge}
+    headers: {}
     status: {code: 200, message: OK}
+version: 1

--- a/fixtures/create_or_update_documents_verbose_failure.yaml
+++ b/fixtures/create_or_update_documents_verbose_failure.yaml
@@ -1,19 +1,15 @@
-- request: !!python/object:vcr.request.Request
+interactions:
+- request:
     body: '{"documents": [{"fields": [{"type": "string", "name": "title"}], "external_id":
       "1"}]}'
-    headers: !!python/object/apply:__builtin__.frozenset
-    - - !!python/tuple [User-Agent, Swiftype-Python/1.1.0]
-      - !!python/tuple [Content-Type, application/json]
-    host: localhost
+    headers:
+      Content-Type: [application/json]
+      User-Agent: [Swiftype-Python/1.1.0]
     method: POST
-    path: /api/v1/engines/api-test/document_types/books/documents/bulk_create_or_update_verbose.json?auth_token=a-test-api-key
-    port: 3000
-    protocol: http
+    uri: http://localhost:3000/api/v1/engines/api-test/document_types/books/documents/bulk_create_or_update_verbose.json?auth_token=a-test-api-key
   response:
     body: {string: '["Invalid field definition: Field definition requires a ''value''
         attribute"]'}
-    headers: {cache-control: 'max-age=0, private, must-revalidate', connection: close,
-      content-type: application/json; charset=utf-8, etag: '"45d92cba10f804a2e430c32f79c06377"',
-      server: thin 1.5.0 codename Knife, x-request-id: 6d1f8c3bbce03e76f9391eaa0085a305,
-      x-runtime: '0.023121', x-ua-compatible: IE=Edge}
+    headers: {}
     status: {code: 200, message: OK}
+version: 1

--- a/fixtures/create_user.yaml
+++ b/fixtures/create_user.yaml
@@ -1,17 +1,13 @@
-- request: !!python/object:vcr.request.Request
+interactions:
+- request:
     body: ''
-    headers: !!python/object/apply:__builtin__.frozenset
-    - - !!python/tuple [User-Agent, Swiftype-Python/1.0.0]
-      - !!python/tuple [Content-Type, application/json]
-    host: localhost
+    headers:
+      Content-Type: [application/json]
+      User-Agent: [Swiftype-Python/1.0.0]
     method: POST
-    path: /api/v1/users.json?client_secret=4441879b5e2a9c3271f5b1a4bc223b715f091e5ed20fe75d1352e1290c7a6dfb&auth_token=a-test-api-key&client_id=3e4fd842fc99aecb4dc50e5b88a186c1e206ddd516cdd336da3622c4afd7e2e9
-    port: 3000
-    protocol: http
+    uri: http://localhost:3000/api/v1/users.json?client_secret=4441879b5e2a9c3271f5b1a4bc223b715f091e5ed20fe75d1352e1290c7a6dfb&auth_token=a-test-api-key&client_id=3e4fd842fc99aecb4dc50e5b88a186c1e206ddd516cdd336da3622c4afd7e2e9
   response:
     body: {string: '{"id":"123456","access_token":"ab169f3343724916d2ccba5e748bdedd6cbf7c06e7d8952530dfa82e1b1052f3"}'}
-    headers: {cache-control: 'max-age=0, private, must-revalidate', connection: close,
-      content-type: application/json; charset=utf-8, etag: '"04764ec2f724ddb8cea4bce79acd93e0"',
-      server: thin 1.5.0 codename Knife, x-request-id: 2237f34063dc0d5802919b5472bcf798,
-      x-runtime: '0.069650', x-ua-compatible: IE=Edge}
+    headers: {}
     status: {code: 200, message: OK}
+version: 1

--- a/fixtures/destroy_document.yaml
+++ b/fixtures/destroy_document.yaml
@@ -1,16 +1,13 @@
-- request: !!python/object:vcr.request.Request
+interactions:
+- request:
     body: ''
-    headers: !!python/object/apply:__builtin__.frozenset
-    - - !!python/tuple [User-Agent, Swiftype-Python/1.0.0]
-      - !!python/tuple [Content-Type, application/json]
-    host: localhost
+    headers:
+      Content-Type: [application/json]
+      User-Agent: [Swiftype-Python/1.0.0]
     method: DELETE
-    path: /api/v1/engines/api-test/document_types/books/documents/doc_id.json?auth_token=a-test-api-key
-    port: 3000
-    protocol: http
+    uri: http://localhost:3000/api/v1/engines/api-test/document_types/books/documents/doc_id.json?auth_token=a-test-api-key
   response:
     body: {string: ''}
-    headers: {cache-control: no-cache, connection: close, server: thin 1.5.0 codename
-        Knife, x-request-id: fe5ad857df6c6323f0e8ebdcefca07fe, x-runtime: '0.034610',
-      x-ua-compatible: IE=Edge}
+    headers: {}
     status: {code: 204, message: No Content}
+version: 1

--- a/fixtures/destroy_document_type.yaml
+++ b/fixtures/destroy_document_type.yaml
@@ -1,16 +1,13 @@
-- request: !!python/object:vcr.request.Request
+interactions:
+- request:
     body: ''
-    headers: !!python/object/apply:__builtin__.frozenset
-    - - !!python/tuple [User-Agent, Swiftype-Python/1.0.0]
-      - !!python/tuple [Content-Type, application/json]
-    host: localhost
+    headers:
+      Content-Type: [application/json]
+      User-Agent: [Swiftype-Python/1.0.0]
     method: DELETE
-    path: /api/v1/engines/api-test/document_types/videos.json?auth_token=a-test-api-key
-    port: 3000
-    protocol: http
+    uri: http://localhost:3000/api/v1/engines/api-test/document_types/videos.json?auth_token=a-test-api-key
   response:
     body: {string: ''}
-    headers: {cache-control: no-cache, connection: close, server: thin 1.5.0 codename
-        Knife, x-request-id: 3ab23265200f30e34a17b8605f113a26, x-runtime: '0.033504',
-      x-ua-compatible: IE=Edge}
+    headers: {}
     status: {code: 204, message: No Content}
+version: 1

--- a/fixtures/destroy_documents.yaml
+++ b/fixtures/destroy_documents.yaml
@@ -1,17 +1,13 @@
-- request: !!python/object:vcr.request.Request
+interactions:
+- request:
     body: '{"documents": ["doc_id1", "doc_id2"]}'
-    headers: !!python/object/apply:__builtin__.frozenset
-    - - !!python/tuple [User-Agent, Swiftype-Python/1.0.0]
-      - !!python/tuple [Content-Type, application/json]
-    host: localhost
+    headers:
+      Content-Type: [application/json]
+      User-Agent: [Swiftype-Python/1.0.0]
     method: POST
-    path: /api/v1/engines/api-test/document_types/books/documents/bulk_destroy.json?auth_token=a-test-api-key
-    port: 3000
-    protocol: http
+    uri: http://localhost:3000/api/v1/engines/api-test/document_types/books/documents/bulk_destroy.json?auth_token=a-test-api-key
   response:
     body: {string: '[true,true]'}
-    headers: {cache-control: 'max-age=0, private, must-revalidate', connection: close,
-      content-type: application/json; charset=utf-8, etag: '"bb009c6dcb5c622766ad5aa1ea1562d9"',
-      server: thin 1.5.0 codename Knife, x-request-id: 9ef3249b7f940c64ce0ec83cdc2e3e38,
-      x-runtime: '0.164122', x-ua-compatible: IE=Edge}
+    headers: {}
     status: {code: 200, message: OK}
+version: 1

--- a/fixtures/destroy_domain.yaml
+++ b/fixtures/destroy_domain.yaml
@@ -1,16 +1,13 @@
-- request: !!python/object:vcr.request.Request
+interactions:
+- request:
     body: ''
-    headers: !!python/object/apply:__builtin__.frozenset
-    - - !!python/tuple [User-Agent, Swiftype-Python/1.0.0]
-      - !!python/tuple [Content-Type, application/json]
-    host: localhost
+    headers:
+      Content-Type: [application/json]
+      User-Agent: [Swiftype-Python/1.0.0]
     method: DELETE
-    path: /api/v1/engines/crawler-demo/domains/52c759423ae7403ec900003b.json?auth_token=a-test-api-key
-    port: 3000
-    protocol: http
+    uri: http://localhost:3000/api/v1/engines/crawler-demo/domains/52c759423ae7403ec900003b.json?auth_token=a-test-api-key
   response:
     body: {string: ''}
-    headers: {cache-control: no-cache, connection: close, server: thin 1.5.0 codename
-        Knife, x-request-id: 0cf7ac1155a5cdc488d63029ce1d0b8e, x-runtime: '0.030385',
-      x-ua-compatible: IE=Edge}
+    headers: {}
     status: {code: 204, message: No Content}
+version: 1

--- a/fixtures/document.yaml
+++ b/fixtures/document.yaml
@@ -1,17 +1,13 @@
-- request: !!python/object:vcr.request.Request
+interactions:
+- request:
     body: ''
-    headers: !!python/object/apply:__builtin__.frozenset
-    - - !!python/tuple [User-Agent, Swiftype-Python/1.0.0]
-      - !!python/tuple [Content-Type, application/json]
-    host: localhost
+    headers:
+      Content-Type: [application/json]
+      User-Agent: [Swiftype-Python/1.0.0]
     method: GET
-    path: /api/v1/engines/api-test/document_types/books/documents/1.json?auth_token=a-test-api-key
-    port: 3000
-    protocol: http
+    uri: http://localhost:3000/api/v1/engines/api-test/document_types/books/documents/1.json?auth_token=a-test-api-key
   response:
     body: {string: '{"external_id":"1","engine_id":"52c73e443ae7403ec900001e","document_type_id":"52c742b63ae7401cb6000004","id":"52c743d73ae7403ec9000024","_id":"52c743d73ae7403ec9000024","updated_at":"2014-01-03T23:18:18Z"}'}
-    headers: {cache-control: 'max-age=0, private, must-revalidate', connection: close,
-      content-type: application/json; charset=utf-8, etag: '"393545095361f67783cb9d25d2628dec"',
-      server: thin 1.5.0 codename Knife, x-request-id: c818a30e3997c01d4e7f8308de078a84,
-      x-runtime: '0.024989', x-ua-compatible: IE=Edge}
+    headers: {}
     status: {code: 200, message: OK}
+version: 1

--- a/fixtures/document_type.yaml
+++ b/fixtures/document_type.yaml
@@ -1,17 +1,13 @@
-- request: !!python/object:vcr.request.Request
+interactions:
+- request:
     body: ''
-    headers: !!python/object/apply:__builtin__.frozenset
-    - - !!python/tuple [User-Agent, Swiftype-Python/1.0.0]
-      - !!python/tuple [Content-Type, application/json]
-    host: localhost
+    headers:
+      Content-Type: [application/json]
+      User-Agent: [Swiftype-Python/1.0.0]
     method: GET
-    path: /api/v1/engines/api-test/document_types/books.json?auth_token=a-test-api-key
-    port: 3000
-    protocol: http
+    uri: http://localhost:3000/api/v1/engines/api-test/document_types/books.json?auth_token=a-test-api-key
   response:
     body: {string: '{"id":"52c742b63ae7401cb6000004","name":"books","slug":"books","engine_id":"52c73e443ae7403ec900001e","updated_at":"2014-01-03T23:43:03Z","document_count":2,"field_mapping":{"external_id":"enum","updated_at":"date","title":"string","author":"string","genre":"enum"}}'}
-    headers: {cache-control: 'max-age=0, private, must-revalidate', connection: close,
-      content-type: application/json; charset=utf-8, etag: '"423bef486ddbef896cf140760a51fb39"',
-      server: thin 1.5.0 codename Knife, x-request-id: 0448681be0040475afaee9ee58727fc9,
-      x-runtime: '0.028258', x-ua-compatible: IE=Edge}
+    headers: {}
     status: {code: 200, message: OK}
+version: 1

--- a/fixtures/document_types.yaml
+++ b/fixtures/document_types.yaml
@@ -1,17 +1,13 @@
-- request: !!python/object:vcr.request.Request
+interactions:
+- request:
     body: ''
-    headers: !!python/object/apply:__builtin__.frozenset
-    - - !!python/tuple [User-Agent, Swiftype-Python/1.0.0]
-      - !!python/tuple [Content-Type, application/json]
-    host: localhost
+    headers:
+      Content-Type: [application/json]
+      User-Agent: [Swiftype-Python/1.0.0]
     method: GET
-    path: /api/v1/engines/api-test/document_types.json?auth_token=a-test-api-key
-    port: 3000
-    protocol: http
+    uri: http://localhost:3000/api/v1/engines/api-test/document_types.json?auth_token=a-test-api-key
   response:
     body: {string: '[{"id":"52c73e443ae7403ec900001d","name":"responses","slug":"responses","engine_id":"52c73e443ae7403ec900001e","updated_at":"2014-01-03T22:48:36Z","document_count":0,"field_mapping":{}},{"id":"52c742b63ae7401cb6000004","name":"books","slug":"books","engine_id":"52c73e443ae7403ec900001e","updated_at":"2014-01-03T23:43:03Z","document_count":2,"field_mapping":{"external_id":"enum","updated_at":"date","title":"string","author":"string","genre":"enum"}}]'}
-    headers: {cache-control: 'max-age=0, private, must-revalidate', connection: close,
-      content-type: application/json; charset=utf-8, etag: '"c3aaeeed9be8d9f4c5816da1aa1d080b"',
-      server: thin 1.5.0 codename Knife, x-request-id: 6f1b21d679e8bf1df51a7dccb3b0f2ef,
-      x-runtime: '0.171236', x-ua-compatible: IE=Edge}
+    headers: {}
     status: {code: 200, message: OK}
+version: 1

--- a/fixtures/documents.yaml
+++ b/fixtures/documents.yaml
@@ -1,18 +1,14 @@
-- request: !!python/object:vcr.request.Request
+interactions:
+- request:
     body: ''
-    headers: !!python/object/apply:__builtin__.frozenset
-    - - !!python/tuple [User-Agent, Swiftype-Python/1.0.0]
-      - !!python/tuple [Content-Type, application/json]
-    host: localhost
+    headers:
+      Content-Type: [application/json]
+      User-Agent: [Swiftype-Python/1.0.0]
     method: GET
-    path: /api/v1/engines/api-test/document_types/books/documents.json?auth_token=a-test-api-key
-    port: 3000
-    protocol: http
+    uri: http://localhost:3000/api/v1/engines/api-test/document_types/books/documents.json?auth_token=a-test-api-key
   response:
     body: {string: '[{"external_id":"1","engine_id":"52c73e443ae7403ec900001e","document_type_id":"52c742b63ae7401cb6000004","id":"52c743d73ae7403ec9000024","_id":"52c743d73ae7403ec9000024","updated_at":"2014-01-03T23:18:18Z"},{"external_id":"2","engine_id":"52c73e443ae7403ec900001e","document_type_id":"52c742b63ae7401cb6000004","id":"52c7444d3ae7403ec9000026","_id":"52c7444d3ae7403ec9000026","updated_at":"2014-01-03T23:32:24Z","title":"new
         title","author":"Fyodor Dostoevsky","genre":"fiction"}]'}
-    headers: {cache-control: 'max-age=0, private, must-revalidate', connection: close,
-      content-type: application/json; charset=utf-8, etag: '"102a1c75b01f11c5f1d92822a111c174"',
-      server: thin 1.5.0 codename Knife, x-request-id: 840837b46a4f184c547fe601e379b19e,
-      x-runtime: '0.177069', x-ua-compatible: IE=Edge}
+    headers: {}
     status: {code: 200, message: OK}
+version: 1

--- a/fixtures/documents_pagination.yaml
+++ b/fixtures/documents_pagination.yaml
@@ -1,18 +1,14 @@
-- request: !!python/object:vcr.request.Request
+interactions:
+- request:
     body: ''
-    headers: !!python/object/apply:__builtin__.frozenset
-    - - !!python/tuple [User-Agent, Swiftype-Python/1.0.0]
-      - !!python/tuple [Content-Type, application/json]
-    host: localhost
+    headers:
+      Content-Type: [application/json]
+      User-Agent: [Swiftype-Python/1.0.0]
     method: GET
-    path: /api/v1/engines/api-test/document_types/books/documents.json?per_page=10&auth_token=a-test-api-key&page=2
-    port: 3000
-    protocol: http
+    uri: http://localhost:3000/api/v1/engines/api-test/document_types/books/documents.json?per_page=10&auth_token=a-test-api-key&page=2
   response:
     body: {string: '[{"external_id":"1","engine_id":"52c73e443ae7403ec900001e","document_type_id":"52c742b63ae7401cb6000004","id":"52c743d73ae7403ec9000024","_id":"52c743d73ae7403ec9000024","updated_at":"2014-01-03T23:18:18Z"},{"external_id":"2","engine_id":"52c73e443ae7403ec900001e","document_type_id":"52c742b63ae7401cb6000004","id":"52c7444d3ae7403ec9000026","_id":"52c7444d3ae7403ec9000026","updated_at":"2014-01-03T23:32:24Z","title":"new
         title","author":"Fyodor Dostoevsky","genre":"fiction"}]'}
-    headers: {cache-control: 'max-age=0, private, must-revalidate', connection: close,
-      content-type: application/json; charset=utf-8, etag: '"d751713988987e9331980363e24189ce"',
-      server: thin 1.5.0 codename Knife, x-request-id: a19d4fe2c8a835c8820c9468796c1b71,
-      x-runtime: '0.027093', x-ua-compatible: IE=Edge}
+    headers: {}
     status: {code: 200, message: OK}
+version: 1

--- a/fixtures/domain.yaml
+++ b/fixtures/domain.yaml
@@ -1,17 +1,13 @@
-- request: !!python/object:vcr.request.Request
+interactions:
+- request:
     body: ''
-    headers: !!python/object/apply:__builtin__.frozenset
-    - - !!python/tuple [User-Agent, Swiftype-Python/1.0.0]
-      - !!python/tuple [Content-Type, application/json]
-    host: localhost
+    headers:
+      Content-Type: [application/json]
+      User-Agent: [Swiftype-Python/1.0.0]
     method: GET
-    path: /api/v1/engines/crawler-demo/domains/52c759423ae7403ec900003b.json?auth_token=a-test-api-key
-    port: 3000
-    protocol: http
+    uri: http://localhost:3000/api/v1/engines/crawler-demo/domains/52c759423ae7403ec900003b.json?auth_token=a-test-api-key
   response:
     body: {string: '{"id":"52c759423ae7403ec900003b","engine_id":"52c74ea83ae7403ec9000032","submitted_url":"http://www.example.com","start_crawl_url":"http://www.example.com/","crawling":false,"document_count":0,"updated_at":"2014-01-04T00:43:53Z"}'}
-    headers: {cache-control: 'max-age=0, private, must-revalidate', connection: close,
-      content-type: application/json; charset=utf-8, etag: '"62e94a0c9adc5454a599bd36cc13c2fe"',
-      server: thin 1.5.0 codename Knife, x-request-id: 6641ef62e19f9ad518765cf22c61c474,
-      x-runtime: '0.022423', x-ua-compatible: IE=Edge}
+    headers: {}
     status: {code: 200, message: OK}
+version: 1

--- a/fixtures/domains.yaml
+++ b/fixtures/domains.yaml
@@ -1,17 +1,13 @@
-- request: !!python/object:vcr.request.Request
+interactions:
+- request:
     body: ''
-    headers: !!python/object/apply:__builtin__.frozenset
-    - - !!python/tuple [User-Agent, Swiftype-Python/1.0.0]
-      - !!python/tuple [Content-Type, application/json]
-    host: localhost
+    headers:
+      Content-Type: [application/json]
+      User-Agent: [Swiftype-Python/1.0.0]
     method: GET
-    path: /api/v1/engines/crawler-demo/domains.json?auth_token=a-test-api-key
-    port: 3000
-    protocol: http
+    uri: http://localhost:3000/api/v1/engines/crawler-demo/domains.json?auth_token=a-test-api-key
   response:
     body: {string: '[{"id":"52c759423ae7403ec900003b","engine_id":"52c74ea83ae7403ec9000032","submitted_url":"http://www.example.com","start_crawl_url":"http://www.example.com/","crawling":false,"document_count":0,"updated_at":"2014-01-04T00:43:53Z"},{"id":"52c754fb3ae7406fd3000001","engine_id":"52c74ea83ae7403ec9000032","submitted_url":"http://crawler-demo-site.herokuapp.com/","start_crawl_url":"http://crawler-demo-site.herokuapp.com/","crawling":false,"document_count":5,"updated_at":"2014-01-06T18:31:12Z"}]'}
-    headers: {cache-control: 'max-age=0, private, must-revalidate', connection: close,
-      content-type: application/json; charset=utf-8, etag: '"4868a2bc81112ff67f2871331ee0497d"',
-      server: thin 1.5.0 codename Knife, x-request-id: c38b6d13d4bd190d2d0e94b1d6ba434d,
-      x-runtime: '0.022666', x-ua-compatible: IE=Edge}
+    headers: {}
     status: {code: 200, message: OK}
+version: 1

--- a/fixtures/engine.yaml
+++ b/fixtures/engine.yaml
@@ -1,17 +1,13 @@
-- request: !!python/object:vcr.request.Request
+interactions:
+- request:
     body: ''
-    headers: !!python/object/apply:__builtin__.frozenset
-    - - !!python/tuple [User-Agent, Swiftype-Python/1.0.0]
-      - !!python/tuple [Content-Type, application/json]
-    host: localhost
+    headers:
+      Content-Type: [application/json]
+      User-Agent: [Swiftype-Python/1.0.0]
     method: GET
-    path: /api/v1/engines/api-test.json?auth_token=a-test-api-key
-    port: 3000
-    protocol: http
+    uri: http://localhost:3000/api/v1/engines/api-test.json?auth_token=a-test-api-key
   response:
     body: {string: '{"name":"api test ","slug":"api-test","key":"k5zFUMeDxn2uFaqzGDrS","id":"52c73e443ae7403ec900001e","_id":"52c73e443ae7403ec900001e","updated_at":"2014-01-03T23:35:21Z","document_count":2}'}
-    headers: {cache-control: 'max-age=0, private, must-revalidate', connection: close,
-      content-type: application/json; charset=utf-8, etag: '"3fdf8ffe743426141b800140db849eb6"',
-      server: thin 1.5.0 codename Knife, x-request-id: c3a3d2406a2644539e1de9592ca9b39f,
-      x-runtime: '0.023034', x-ua-compatible: IE=Edge}
+    headers: {}
     status: {code: 200, message: OK}
+version: 1

--- a/fixtures/engine_create.yaml
+++ b/fixtures/engine_create.yaml
@@ -1,17 +1,13 @@
-- request: !!python/object:vcr.request.Request
+interactions:
+- request:
     body: '{"engine": {"name": "myengine"}}'
-    headers: !!python/object/apply:__builtin__.frozenset
-    - - !!python/tuple [User-Agent, Swiftype-Python/1.0.0]
-      - !!python/tuple [Content-Type, application/json]
-    host: localhost
+    headers:
+      Content-Type: [application/json]
+      User-Agent: [Swiftype-Python/1.0.0]
     method: POST
-    path: /api/v1/engines.json?auth_token=a-test-api-key
-    port: 3000
-    protocol: http
+    uri: http://localhost:3000/api/v1/engines.json?auth_token=a-test-api-key
   response:
     body: {string: '{"name":"myengine","slug":"myengine","key":"ziLaAWiqF1VpspxTTp3J","id":"52cb2bda3ae7403ec9000048","_id":"52cb2bda3ae7403ec9000048","updated_at":"2014-01-06T22:19:06Z","document_count":0}'}
-    headers: {cache-control: 'max-age=0, private, must-revalidate', connection: close,
-      content-type: application/json; charset=utf-8, etag: '"aa8d31b44a267ae9dd90ddb1cd02fe7c"',
-      server: thin 1.5.0 codename Knife, x-request-id: abfc9415006498b825e06a3273b34cd6,
-      x-runtime: '0.157257', x-ua-compatible: IE=Edge}
+    headers: {}
     status: {code: 200, message: OK}
+version: 1

--- a/fixtures/engine_destroy.yaml
+++ b/fixtures/engine_destroy.yaml
@@ -1,16 +1,13 @@
-- request: !!python/object:vcr.request.Request
+interactions:
+- request:
     body: ''
-    headers: !!python/object/apply:__builtin__.frozenset
-    - - !!python/tuple [User-Agent, Swiftype-Python/1.0.0]
-      - !!python/tuple [Content-Type, application/json]
-    host: localhost
+    headers:
+      Content-Type: [application/json]
+      User-Agent: [Swiftype-Python/1.0.0]
     method: DELETE
-    path: /api/v1/engines/myengine.json?auth_token=a-test-api-key
-    port: 3000
-    protocol: http
+    uri: http://localhost:3000/api/v1/engines/myengine.json?auth_token=a-test-api-key
   response:
     body: {string: ''}
-    headers: {cache-control: no-cache, connection: close, server: thin 1.5.0 codename
-        Knife, x-request-id: eebb3799708667eaab665af3d945ad19, x-runtime: '0.026874',
-      x-ua-compatible: IE=Edge}
+    headers: {}
     status: {code: 204, message: No Content}
+version: 1

--- a/fixtures/engines.yaml
+++ b/fixtures/engines.yaml
@@ -1,17 +1,14 @@
-- request: !!python/object:vcr.request.Request
+interactions:
+- request:
     body: ''
-    headers: !!python/object/apply:__builtin__.frozenset
-    - - !!python/tuple [User-Agent, Swiftype-Python/1.0.0]
-      - !!python/tuple [Content-Type, application/json]
-    host: localhost
+    headers:
+      Content-Type: [application/json]
+      User-Agent: [Swiftype-Python/1.0.0]
     method: GET
-    path: /api/v1/engines.json?auth_token=a-test-api-key
-    port: 3000
-    protocol: http
+    uri: http://localhost:3000/api/v1/engines.json?auth_token=a-test-api-key
   response:
-    body: {string: '[{"name":"api test ","slug":"api-test","key":"k5zFUMeDxn2uFaqzGDrS","id":"52c73e443ae7403ec900001e","_id":"52c73e443ae7403ec900001e","updated_at":"2014-01-03T23:35:21Z","document_count":2},{"name":"Crawler Demo","slug":"crawler-demo","key":"whYbNeFx9D1PQg8xXv8H","id":"52c74ea83ae7403ec9000032","_id":"52c74ea83ae7403ec9000032","updated_at":"2014-01-03T23:58:37Z","document_count":17},{"name":"engine","slug":"engine","key":"zicsWdgY3hFLqqQGRBg1","id":"52c73b833ae7403ec9000012","_id":"52c73b833ae7403ec9000012","updated_at":"2014-01-03T22:36:51Z","document_count":0}]'}
-    headers: {cache-control: 'max-age=0, private, must-revalidate', connection: close,
-      content-type: application/json; charset=utf-8, etag: '"7df191d30e4d8809e5b910b7a5cfc369"',
-      server: thin 1.5.0 codename Knife, x-request-id: e2536ffcbcc7903d949c0787fbe665ab,
-      x-runtime: '0.022098', x-ua-compatible: IE=Edge}
+    body: {string: '[{"name":"api test ","slug":"api-test","key":"k5zFUMeDxn2uFaqzGDrS","id":"52c73e443ae7403ec900001e","_id":"52c73e443ae7403ec900001e","updated_at":"2014-01-03T23:35:21Z","document_count":2},{"name":"Crawler
+        Demo","slug":"crawler-demo","key":"whYbNeFx9D1PQg8xXv8H","id":"52c74ea83ae7403ec9000032","_id":"52c74ea83ae7403ec9000032","updated_at":"2014-01-03T23:58:37Z","document_count":17},{"name":"engine","slug":"engine","key":"zicsWdgY3hFLqqQGRBg1","id":"52c73b833ae7403ec9000012","_id":"52c73b833ae7403ec9000012","updated_at":"2014-01-03T22:36:51Z","document_count":0}]'}
+    headers: {}
     status: {code: 200, message: OK}
+version: 1

--- a/fixtures/platform_create_document.yaml
+++ b/fixtures/platform_create_document.yaml
@@ -1,18 +1,14 @@
-- request: !!python/object:vcr.request.Request
+interactions:
+- request:
     body: '{"document": {"external_id": "doc_id"}}'
-    headers: !!python/object/apply:__builtin__.frozenset
-    - - !!python/tuple [User-Agent, Swiftype-Python/1.0.0]
-      - !!python/tuple [Authorization, Bearer 6cf7fbd297f00a8e3863a0595f55ff7d141cbef2fcbe00159d0f7403649b384e]
-      - !!python/tuple [Content-Type, application/json]
-    host: localhost
+    headers:
+      Authorization: [Bearer 6cf7fbd297f00a8e3863a0595f55ff7d141cbef2fcbe00159d0f7403649b384e]
+      Content-Type: [application/json]
+      User-Agent: [Swiftype-Python/1.0.0]
     method: POST
-    path: /api/v1/engines/myusersengine/document_types/videos/documents.json
-    port: 3000
-    protocol: http
+    uri: http://localhost:3000/api/v1/engines/myusersengine/document_types/videos/documents.json
   response:
     body: {string: '{"external_id":"doc_id","engine_id":"52cca3f13ae740f4af000023","document_type_id":"52cca4a43ae740f4af000024","id":"52cca54f3ae740f4af000026","_id":"52cca54f3ae740f4af000026","updated_at":"2014-01-08T01:09:35Z"}'}
-    headers: {cache-control: 'max-age=0, private, must-revalidate', connection: close,
-      content-type: application/json; charset=utf-8, etag: '"2f47ab1d3d64e1f401758e0c1adba376"',
-      server: thin 1.5.0 codename Knife, x-request-id: e3747b602f410044648906559a79ce4f,
-      x-runtime: '0.176010', x-ua-compatible: IE=Edge}
+    headers: {}
     status: {code: 200, message: OK}
+version: 1

--- a/fixtures/platform_create_document_type.yaml
+++ b/fixtures/platform_create_document_type.yaml
@@ -1,18 +1,14 @@
-- request: !!python/object:vcr.request.Request
+interactions:
+- request:
     body: '{"document_type": {"name": "videos"}}'
-    headers: !!python/object/apply:__builtin__.frozenset
-    - - !!python/tuple [User-Agent, Swiftype-Python/1.0.0]
-      - !!python/tuple [Authorization, Bearer 6cf7fbd297f00a8e3863a0595f55ff7d141cbef2fcbe00159d0f7403649b384e]
-      - !!python/tuple [Content-Type, application/json]
-    host: localhost
+    headers:
+      Authorization: [Bearer 6cf7fbd297f00a8e3863a0595f55ff7d141cbef2fcbe00159d0f7403649b384e]
+      Content-Type: [application/json]
+      User-Agent: [Swiftype-Python/1.0.0]
     method: POST
-    path: /api/v1/engines/myusersengine/document_types.json
-    port: 3000
-    protocol: http
+    uri: http://localhost:3000/api/v1/engines/myusersengine/document_types.json
   response:
     body: {string: '{"id":"52cca4a43ae740f4af000024","name":"videos","slug":"videos","engine_id":"52cca3f13ae740f4af000023","updated_at":"2014-01-08T01:06:44Z","document_count":0,"field_mapping":{}}'}
-    headers: {cache-control: 'max-age=0, private, must-revalidate', connection: close,
-      content-type: application/json; charset=utf-8, etag: '"18cf4a2934702f8d1872273ee78b544c"',
-      server: thin 1.5.0 codename Knife, x-request-id: 5df4547c828f6c5f32852192d3fefe12,
-      x-runtime: '0.131149', x-ua-compatible: IE=Edge}
+    headers: {}
     status: {code: 200, message: OK}
+version: 1

--- a/fixtures/platform_create_documents.yaml
+++ b/fixtures/platform_create_documents.yaml
@@ -1,18 +1,14 @@
-- request: !!python/object:vcr.request.Request
+interactions:
+- request:
     body: '{"documents": [{"external_id": "doc_id1"}, {"external_id": "doc_id2"}]}'
-    headers: !!python/object/apply:__builtin__.frozenset
-    - - !!python/tuple [User-Agent, Swiftype-Python/1.0.0]
-      - !!python/tuple [Authorization, Bearer 6cf7fbd297f00a8e3863a0595f55ff7d141cbef2fcbe00159d0f7403649b384e]
-      - !!python/tuple [Content-Type, application/json]
-    host: localhost
+    headers:
+      Authorization: [Bearer 6cf7fbd297f00a8e3863a0595f55ff7d141cbef2fcbe00159d0f7403649b384e]
+      Content-Type: [application/json]
+      User-Agent: [Swiftype-Python/1.0.0]
     method: POST
-    path: /api/v1/engines/myusersengine/document_types/videos/documents/bulk_create.json
-    port: 3000
-    protocol: http
+    uri: http://localhost:3000/api/v1/engines/myusersengine/document_types/videos/documents/bulk_create.json
   response:
     body: {string: '[true,true]'}
-    headers: {cache-control: 'max-age=0, private, must-revalidate', connection: close,
-      content-type: application/json; charset=utf-8, etag: '"bb009c6dcb5c622766ad5aa1ea1562d9"',
-      server: thin 1.5.0 codename Knife, x-request-id: 2453d94eb997eaa1501e4afcb91b1372,
-      x-runtime: '0.143837', x-ua-compatible: IE=Edge}
+    headers: {}
     status: {code: 200, message: OK}
+version: 1

--- a/fixtures/platform_engine_create.yaml
+++ b/fixtures/platform_engine_create.yaml
@@ -1,18 +1,14 @@
-- request: !!python/object:vcr.request.Request
+interactions:
+- request:
     body: '{"engine": {"name": "myusersengine"}}'
-    headers: !!python/object/apply:__builtin__.frozenset
-    - - !!python/tuple [User-Agent, Swiftype-Python/1.0.0]
-      - !!python/tuple [Authorization, Bearer 6cf7fbd297f00a8e3863a0595f55ff7d141cbef2fcbe00159d0f7403649b384e]
-      - !!python/tuple [Content-Type, application/json]
-    host: localhost
+    headers:
+      Authorization: [Bearer 6cf7fbd297f00a8e3863a0595f55ff7d141cbef2fcbe00159d0f7403649b384e]
+      Content-Type: [application/json]
+      User-Agent: [Swiftype-Python/1.0.0]
     method: POST
-    path: /api/v1/engines.json
-    port: 3000
-    protocol: http
+    uri: http://localhost:3000/api/v1/engines.json
   response:
     body: {string: '{"name":"myusersengine","slug":"myusersengine","key":"wLDDEvF4GetXAkx6xiss","id":"52ccaa333ae740f4af00002b","_id":"52ccaa333ae740f4af00002b","updated_at":"2014-01-08T01:30:27Z","document_count":0}'}
-    headers: {cache-control: 'max-age=0, private, must-revalidate', connection: close,
-      content-type: application/json; charset=utf-8, etag: '"8240b4e5c212143eb3e570e548c4d8d5"',
-      server: thin 1.5.0 codename Knife, x-request-id: 7ba05f6eb9c0d05aad3ce4ca5b1d8598,
-      x-runtime: '0.146829', x-ua-compatible: IE=Edge}
+    headers: {}
     status: {code: 200, message: OK}
+version: 1

--- a/fixtures/platform_engine_destroy.yaml
+++ b/fixtures/platform_engine_destroy.yaml
@@ -1,17 +1,14 @@
-- request: !!python/object:vcr.request.Request
+interactions:
+- request:
     body: ''
-    headers: !!python/object/apply:__builtin__.frozenset
-    - - !!python/tuple [User-Agent, Swiftype-Python/1.0.0]
-      - !!python/tuple [Authorization, Bearer 6cf7fbd297f00a8e3863a0595f55ff7d141cbef2fcbe00159d0f7403649b384e]
-      - !!python/tuple [Content-Type, application/json]
-    host: localhost
+    headers:
+      Authorization: [Bearer 6cf7fbd297f00a8e3863a0595f55ff7d141cbef2fcbe00159d0f7403649b384e]
+      Content-Type: [application/json]
+      User-Agent: [Swiftype-Python/1.0.0]
     method: DELETE
-    path: /api/v1/engines/myuserengine.json
-    port: 3000
-    protocol: http
+    uri: http://localhost:3000/api/v1/engines/myuserengine.json
   response:
     body: {string: '{"error":"Permission denied."}'}
-    headers: {cache-control: no-cache, connection: close, content-type: application/json;
-        charset=utf-8, server: thin 1.5.0 codename Knife, x-request-id: 1ce7984333c15a3fb5c158dadddb61e8,
-      x-runtime: '0.021690', x-ua-compatible: IE=Edge}
+    headers: {}
     status: {code: 403, message: Forbidden}
+version: 1

--- a/fixtures/recrawl_domain.yaml
+++ b/fixtures/recrawl_domain.yaml
@@ -1,17 +1,13 @@
-- request: !!python/object:vcr.request.Request
+interactions:
+- request:
     body: ''
-    headers: !!python/object/apply:__builtin__.frozenset
-    - - !!python/tuple [User-Agent, Swiftype-Python/1.0.0]
-      - !!python/tuple [Content-Type, application/json]
-    host: localhost
+    headers:
+      Content-Type: [application/json]
+      User-Agent: [Swiftype-Python/1.0.0]
     method: PUT
-    path: /api/v1/engines/crawler-demo/domains/52c754fb3ae7406fd3000001/recrawl.json?auth_token=a-test-api-key
-    port: 3000
-    protocol: http
+    uri: http://localhost:3000/api/v1/engines/crawler-demo/domains/52c754fb3ae7406fd3000001/recrawl.json?auth_token=a-test-api-key
   response:
     body: {string: '{"id":"52c754fb3ae7406fd3000001","engine_id":"52c74ea83ae7403ec9000032","submitted_url":"http://crawler-demo-site.herokuapp.com/","start_crawl_url":"http://crawler-demo-site.herokuapp.com/","crawling":false,"document_count":5,"updated_at":"2014-01-06T22:17:01Z"}'}
-    headers: {cache-control: 'max-age=0, private, must-revalidate', connection: close,
-      content-type: application/json; charset=utf-8, etag: '"83a03ddf0f7817d89dc33598797cd88d"',
-      server: thin 1.5.0 codename Knife, x-request-id: 544ba3c3e502a665e926d91d231934c9,
-      x-runtime: '0.023721', x-ua-compatible: IE=Edge}
+    headers: {}
     status: {code: 200, message: OK}
+version: 1

--- a/fixtures/search.yaml
+++ b/fixtures/search.yaml
@@ -1,34 +1,24 @@
-- request: !!python/object:vcr.request.Request
+interactions:
+- request:
     body: ''
-    headers: !!python/object/apply:__builtin__.frozenset
-    - - !!python/tuple [User-Agent, Swiftype-Python/1.0.0]
-      - !!python/tuple [Content-Type, application/json]
-    host: localhost
+    headers:
+      Content-Type: [application/json]
+      User-Agent: [Swiftype-Python/1.0.0]
     method: GET
-    path: /api/v1/engines/api-test/document_types.json?auth_token=a-test-api-key
-    port: 3000
-    protocol: http
+    uri: http://localhost:3000/api/v1/engines/api-test/document_types.json?auth_token=a-test-api-key
   response:
     body: {string: '[{"id":"52c73e443ae7403ec900001d","name":"responses","slug":"responses","engine_id":"52c73e443ae7403ec900001e","updated_at":"2014-01-03T22:48:36Z","document_count":0,"field_mapping":{}},{"id":"52c742b63ae7401cb6000004","name":"books","slug":"books","engine_id":"52c73e443ae7403ec900001e","updated_at":"2014-01-03T23:43:03Z","document_count":2,"field_mapping":{"external_id":"enum","updated_at":"date","title":"string","author":"string","genre":"enum"}}]'}
-    headers: {cache-control: 'max-age=0, private, must-revalidate', connection: close,
-      content-type: application/json; charset=utf-8, etag: '"c3aaeeed9be8d9f4c5816da1aa1d080b"',
-      server: thin 1.5.0 codename Knife, x-request-id: c3d68bf4b8b093ec08faae71699e7f11,
-      x-runtime: '0.029246', x-ua-compatible: IE=Edge}
+    headers: {}
     status: {code: 200, message: OK}
-- request: !!python/object:vcr.request.Request
+- request:
     body: '{"q": "*"}'
-    headers: !!python/object/apply:__builtin__.frozenset
-    - - !!python/tuple [User-Agent, Swiftype-Python/1.0.0]
-      - !!python/tuple [Content-Type, application/json]
-    host: localhost
+    headers:
+      Content-Type: [application/json]
+      User-Agent: [Swiftype-Python/1.0.0]
     method: GET
-    path: /api/v1/engines/api-test/search.json?auth_token=a-test-api-key
-    port: 3000
-    protocol: http
+    uri: http://localhost:3000/api/v1/engines/api-test/search.json?auth_token=a-test-api-key
   response:
     body: {string: '{"records":{"responses":[],"books":[]},"info":{"responses":{"query":"*","current_page":1,"num_pages":0,"per_page":20,"total_result_count":0,"facets":{}},"books":{"query":"*","current_page":1,"num_pages":0,"per_page":20,"total_result_count":0,"facets":{}}},"errors":{}}'}
-    headers: {cache-control: 'max-age=0, private, must-revalidate', connection: close,
-      content-type: application/json; charset=utf-8, etag: '"3a93ced86df99a964e47d8f49b3f060c"',
-      server: thin 1.5.0 codename Knife, x-request-id: feee3c7de40cca0a329bfbdc2455f98c,
-      x-runtime: '0.303923', x-ua-compatible: IE=Edge}
+    headers: {}
     status: {code: 200, message: OK}
+version: 1

--- a/fixtures/search_document_type.yaml
+++ b/fixtures/search_document_type.yaml
@@ -1,17 +1,13 @@
-- request: !!python/object:vcr.request.Request
+interactions:
+- request:
     body: '{"q": "*"}'
-    headers: !!python/object/apply:__builtin__.frozenset
-    - - !!python/tuple [User-Agent, Swiftype-Python/1.0.0]
-      - !!python/tuple [Content-Type, application/json]
-    host: localhost
+    headers:
+      Content-Type: [application/json]
+      User-Agent: [Swiftype-Python/1.0.0]
     method: GET
-    path: /api/v1/engines/api-test/document_types/books/search.json?auth_token=a-test-api-key
-    port: 3000
-    protocol: http
+    uri: http://localhost:3000/api/v1/engines/api-test/document_types/books/search.json?auth_token=a-test-api-key
   response:
     body: {string: '{"records":{"books":[]},"info":{"books":{"query":"*","current_page":1,"num_pages":0,"per_page":20,"total_result_count":0,"facets":{}}},"errors":{}}'}
-    headers: {cache-control: 'max-age=0, private, must-revalidate', connection: close,
-      content-type: application/json; charset=utf-8, etag: '"aa7211328ce157794f5c3e79805377e2"',
-      server: thin 1.5.0 codename Knife, x-request-id: 95e4164f8ca8502c868655c3fe698e5e,
-      x-runtime: '0.156261', x-ua-compatible: IE=Edge}
+    headers: {}
     status: {code: 200, message: OK}
+version: 1

--- a/fixtures/search_document_type_with_options.yaml
+++ b/fixtures/search_document_type_with_options.yaml
@@ -1,17 +1,13 @@
-- request: !!python/object:vcr.request.Request
+interactions:
+- request:
     body: '{"q": "query", "page": 2}'
-    headers: !!python/object/apply:__builtin__.frozenset
-    - - !!python/tuple [User-Agent, Swiftype-Python/1.0.0]
-      - !!python/tuple [Content-Type, application/json]
-    host: localhost
+    headers:
+      Content-Type: [application/json]
+      User-Agent: [Swiftype-Python/1.0.0]
     method: GET
-    path: /api/v1/engines/api-test/document_types/books/search.json?auth_token=a-test-api-key
-    port: 3000
-    protocol: http
+    uri: http://localhost:3000/api/v1/engines/api-test/document_types/books/search.json?auth_token=a-test-api-key
   response:
     body: {string: '{"records":{"books":[]},"info":{"books":{"query":"query","current_page":2,"num_pages":0,"per_page":20,"total_result_count":0,"facets":{}}},"errors":{}}'}
-    headers: {cache-control: 'max-age=0, private, must-revalidate', connection: close,
-      content-type: application/json; charset=utf-8, etag: '"cd4813bac75f9c88236d4c994314628f"',
-      server: thin 1.5.0 codename Knife, x-request-id: 3e700431a09ff9f8fc5a65d378e282e2,
-      x-runtime: '0.157285', x-ua-compatible: IE=Edge}
+    headers: {}
     status: {code: 200, message: OK}
+version: 1

--- a/fixtures/search_with_options.yaml
+++ b/fixtures/search_with_options.yaml
@@ -1,34 +1,24 @@
-- request: !!python/object:vcr.request.Request
+interactions:
+- request:
     body: ''
-    headers: !!python/object/apply:__builtin__.frozenset
-    - - !!python/tuple [User-Agent, Swiftype-Python/1.0.0]
-      - !!python/tuple [Content-Type, application/json]
-    host: localhost
+    headers:
+      Content-Type: [application/json]
+      User-Agent: [Swiftype-Python/1.0.0]
     method: GET
-    path: /api/v1/engines/api-test/document_types.json?auth_token=a-test-api-key
-    port: 3000
-    protocol: http
+    uri: http://localhost:3000/api/v1/engines/api-test/document_types.json?auth_token=a-test-api-key
   response:
     body: {string: '[{"id":"52c73e443ae7403ec900001d","name":"responses","slug":"responses","engine_id":"52c73e443ae7403ec900001e","updated_at":"2014-01-03T22:48:36Z","document_count":0,"field_mapping":{}},{"id":"52c742b63ae7401cb6000004","name":"books","slug":"books","engine_id":"52c73e443ae7403ec900001e","updated_at":"2014-01-03T23:43:03Z","document_count":2,"field_mapping":{"external_id":"enum","updated_at":"date","title":"string","author":"string","genre":"enum"}}]'}
-    headers: {cache-control: 'max-age=0, private, must-revalidate', connection: close,
-      content-type: application/json; charset=utf-8, etag: '"c3aaeeed9be8d9f4c5816da1aa1d080b"',
-      server: thin 1.5.0 codename Knife, x-request-id: 6caeb1b22b5eafdfdc33170e59bb4304,
-      x-runtime: '0.021331', x-ua-compatible: IE=Edge}
+    headers: {}
     status: {code: 200, message: OK}
-- request: !!python/object:vcr.request.Request
+- request:
     body: '{"q": "query", "page": 2}'
-    headers: !!python/object/apply:__builtin__.frozenset
-    - - !!python/tuple [User-Agent, Swiftype-Python/1.0.0]
-      - !!python/tuple [Content-Type, application/json]
-    host: localhost
+    headers:
+      Content-Type: [application/json]
+      User-Agent: [Swiftype-Python/1.0.0]
     method: GET
-    path: /api/v1/engines/api-test/search.json?auth_token=a-test-api-key
-    port: 3000
-    protocol: http
+    uri: http://localhost:3000/api/v1/engines/api-test/search.json?auth_token=a-test-api-key
   response:
     body: {string: '{"records":{"responses":[],"books":[]},"info":{"responses":{"query":"query","current_page":2,"num_pages":0,"per_page":20,"total_result_count":0,"facets":{}},"books":{"query":"query","current_page":2,"num_pages":0,"per_page":20,"total_result_count":0,"facets":{}}},"errors":{}}'}
-    headers: {cache-control: 'max-age=0, private, must-revalidate', connection: close,
-      content-type: application/json; charset=utf-8, etag: '"58a83e3bd528760413758c355402661a"',
-      server: thin 1.5.0 codename Knife, x-request-id: 9f68fbc242d5b60082d85214e9914bd4,
-      x-runtime: '0.170619', x-ua-compatible: IE=Edge}
+    headers: {}
     status: {code: 200, message: OK}
+version: 1

--- a/fixtures/suggest.yaml
+++ b/fixtures/suggest.yaml
@@ -1,34 +1,24 @@
-- request: !!python/object:vcr.request.Request
+interactions:
+- request:
     body: ''
-    headers: !!python/object/apply:__builtin__.frozenset
-    - - !!python/tuple [User-Agent, Swiftype-Python/1.0.0]
-      - !!python/tuple [Content-Type, application/json]
-    host: localhost
+    headers:
+      Content-Type: [application/json]
+      User-Agent: [Swiftype-Python/1.0.0]
     method: GET
-    path: /api/v1/engines/api-test/document_types.json?auth_token=a-test-api-key
-    port: 3000
-    protocol: http
+    uri: http://localhost:3000/api/v1/engines/api-test/document_types.json?auth_token=a-test-api-key
   response:
     body: {string: '[{"id":"52c73e443ae7403ec900001d","name":"responses","slug":"responses","engine_id":"52c73e443ae7403ec900001e","updated_at":"2014-01-03T22:48:36Z","document_count":0,"field_mapping":{}},{"id":"52c742b63ae7401cb6000004","name":"books","slug":"books","engine_id":"52c73e443ae7403ec900001e","updated_at":"2014-01-03T23:43:03Z","document_count":2,"field_mapping":{"external_id":"enum","updated_at":"date","title":"string","author":"string","genre":"enum"}}]'}
-    headers: {cache-control: 'max-age=0, private, must-revalidate', connection: close,
-      content-type: application/json; charset=utf-8, etag: '"c3aaeeed9be8d9f4c5816da1aa1d080b"',
-      server: thin 1.5.0 codename Knife, x-request-id: 4dcd0e5eac07de6fef7ae88f1a37369d,
-      x-runtime: '0.021395', x-ua-compatible: IE=Edge}
+    headers: {}
     status: {code: 200, message: OK}
-- request: !!python/object:vcr.request.Request
+- request:
     body: '{"q": "*"}'
-    headers: !!python/object/apply:__builtin__.frozenset
-    - - !!python/tuple [User-Agent, Swiftype-Python/1.0.0]
-      - !!python/tuple [Content-Type, application/json]
-    host: localhost
+    headers:
+      Content-Type: [application/json]
+      User-Agent: [Swiftype-Python/1.0.0]
     method: GET
-    path: /api/v1/engines/api-test/suggest.json?auth_token=a-test-api-key
-    port: 3000
-    protocol: http
+    uri: http://localhost:3000/api/v1/engines/api-test/suggest.json?auth_token=a-test-api-key
   response:
     body: {string: '{"record_count":0,"records":{"responses":[],"books":[]},"info":{},"errors":{}}'}
-    headers: {cache-control: 'max-age=0, private, must-revalidate', connection: close,
-      content-type: application/json; charset=utf-8, etag: '"454b01de630ec23114367c9ddff47749"',
-      server: thin 1.5.0 codename Knife, x-request-id: 590f5bb1abb595bb692df16fcf3e449d,
-      x-runtime: '0.026560', x-ua-compatible: IE=Edge}
+    headers: {}
     status: {code: 200, message: OK}
+version: 1

--- a/fixtures/suggest_document_type.yaml
+++ b/fixtures/suggest_document_type.yaml
@@ -1,17 +1,13 @@
-- request: !!python/object:vcr.request.Request
+interactions:
+- request:
     body: '{"q": "*"}'
-    headers: !!python/object/apply:__builtin__.frozenset
-    - - !!python/tuple [User-Agent, Swiftype-Python/1.0.0]
-      - !!python/tuple [Content-Type, application/json]
-    host: localhost
+    headers:
+      Content-Type: [application/json]
+      User-Agent: [Swiftype-Python/1.0.0]
     method: GET
-    path: /api/v1/engines/api-test/document_types/books/suggest.json?auth_token=a-test-api-key
-    port: 3000
-    protocol: http
+    uri: http://localhost:3000/api/v1/engines/api-test/document_types/books/suggest.json?auth_token=a-test-api-key
   response:
     body: {string: '{"record_count":0,"records":{"books":[]},"info":{},"errors":{}}'}
-    headers: {cache-control: 'max-age=0, private, must-revalidate', connection: close,
-      content-type: application/json; charset=utf-8, etag: '"20428e8ad5cf78efaddde54348ffe175"',
-      server: thin 1.5.0 codename Knife, x-request-id: 8482503cc07b1c1d5404412f1d7083ed,
-      x-runtime: '0.024148', x-ua-compatible: IE=Edge}
+    headers: {}
     status: {code: 200, message: OK}
+version: 1

--- a/fixtures/suggest_document_type_with_options.yaml
+++ b/fixtures/suggest_document_type_with_options.yaml
@@ -1,17 +1,13 @@
-- request: !!python/object:vcr.request.Request
+interactions:
+- request:
     body: '{"q": "query", "page": 2}'
-    headers: !!python/object/apply:__builtin__.frozenset
-    - - !!python/tuple [User-Agent, Swiftype-Python/1.0.0]
-      - !!python/tuple [Content-Type, application/json]
-    host: localhost
+    headers:
+      Content-Type: [application/json]
+      User-Agent: [Swiftype-Python/1.0.0]
     method: GET
-    path: /api/v1/engines/api-test/document_types/books/suggest.json?auth_token=a-test-api-key
-    port: 3000
-    protocol: http
+    uri: http://localhost:3000/api/v1/engines/api-test/document_types/books/suggest.json?auth_token=a-test-api-key
   response:
     body: {string: '{"record_count":0,"records":{"books":[]},"info":{"books":{"query":"query","current_page":2,"num_pages":0,"per_page":10,"total_result_count":0}},"errors":{}}'}
-    headers: {cache-control: 'max-age=0, private, must-revalidate', connection: close,
-      content-type: application/json; charset=utf-8, etag: '"61abca1ad081484d71cb75c21828cebb"',
-      server: thin 1.5.0 codename Knife, x-request-id: b7af53e7f67af60e0850c1c3bd0cd9c6,
-      x-runtime: '0.161858', x-ua-compatible: IE=Edge}
+    headers: {}
     status: {code: 200, message: OK}
+version: 1

--- a/fixtures/suggest_with_options.yaml
+++ b/fixtures/suggest_with_options.yaml
@@ -1,34 +1,24 @@
-- request: !!python/object:vcr.request.Request
+interactions:
+- request:
     body: ''
-    headers: !!python/object/apply:__builtin__.frozenset
-    - - !!python/tuple [User-Agent, Swiftype-Python/1.0.0]
-      - !!python/tuple [Content-Type, application/json]
-    host: localhost
+    headers:
+      Content-Type: [application/json]
+      User-Agent: [Swiftype-Python/1.0.0]
     method: GET
-    path: /api/v1/engines/api-test/document_types.json?auth_token=a-test-api-key
-    port: 3000
-    protocol: http
+    uri: http://localhost:3000/api/v1/engines/api-test/document_types.json?auth_token=a-test-api-key
   response:
     body: {string: '[{"id":"52c73e443ae7403ec900001d","name":"responses","slug":"responses","engine_id":"52c73e443ae7403ec900001e","updated_at":"2014-01-03T22:48:36Z","document_count":0,"field_mapping":{}},{"id":"52c742b63ae7401cb6000004","name":"books","slug":"books","engine_id":"52c73e443ae7403ec900001e","updated_at":"2014-01-03T23:43:03Z","document_count":2,"field_mapping":{"external_id":"enum","updated_at":"date","title":"string","author":"string","genre":"enum"}}]'}
-    headers: {cache-control: 'max-age=0, private, must-revalidate', connection: close,
-      content-type: application/json; charset=utf-8, etag: '"c3aaeeed9be8d9f4c5816da1aa1d080b"',
-      server: thin 1.5.0 codename Knife, x-request-id: aca7005d5acf73c21233203494912ac7,
-      x-runtime: '0.021567', x-ua-compatible: IE=Edge}
+    headers: {}
     status: {code: 200, message: OK}
-- request: !!python/object:vcr.request.Request
+- request:
     body: '{"q": "query", "page": 2}'
-    headers: !!python/object/apply:__builtin__.frozenset
-    - - !!python/tuple [User-Agent, Swiftype-Python/1.0.0]
-      - !!python/tuple [Content-Type, application/json]
-    host: localhost
+    headers:
+      Content-Type: [application/json]
+      User-Agent: [Swiftype-Python/1.0.0]
     method: GET
-    path: /api/v1/engines/api-test/suggest.json?auth_token=a-test-api-key
-    port: 3000
-    protocol: http
+    uri: http://localhost:3000/api/v1/engines/api-test/suggest.json?auth_token=a-test-api-key
   response:
     body: {string: '{"record_count":0,"records":{"responses":[],"books":[]},"info":{"responses":{"query":"query","current_page":2,"num_pages":0,"per_page":10,"total_result_count":0},"books":{"query":"query","current_page":2,"num_pages":0,"per_page":10,"total_result_count":0}},"errors":{}}'}
-    headers: {cache-control: 'max-age=0, private, must-revalidate', connection: close,
-      content-type: application/json; charset=utf-8, etag: '"31cb1c8467dd87a752cd76fc152f9b78"',
-      server: thin 1.5.0 codename Knife, x-request-id: b96f335cbac289ec20d1999812534b77,
-      x-runtime: '0.176308', x-ua-compatible: IE=Edge}
+    headers: {}
     status: {code: 200, message: OK}
+version: 1

--- a/fixtures/update_document.yaml
+++ b/fixtures/update_document.yaml
@@ -1,18 +1,14 @@
-- request: !!python/object:vcr.request.Request
+interactions:
+- request:
     body: '{"fields": {"title": "a new title"}}'
-    headers: !!python/object/apply:__builtin__.frozenset
-    - - !!python/tuple [User-Agent, Swiftype-Python/1.0.0]
-      - !!python/tuple [Content-Type, application/json]
-    host: localhost
+    headers:
+      Content-Type: [application/json]
+      User-Agent: [Swiftype-Python/1.0.0]
     method: PUT
-    path: /api/v1/engines/api-test/document_types/books/documents/2/update_fields.json?auth_token=a-test-api-key
-    port: 3000
-    protocol: http
+    uri: http://localhost:3000/api/v1/engines/api-test/document_types/books/documents/2/update_fields.json?auth_token=a-test-api-key
   response:
     body: {string: '{"external_id":"2","engine_id":"52c73e443ae7403ec900001e","document_type_id":"52c742b63ae7401cb6000004","id":"52c7444d3ae7403ec9000026","_id":"52c7444d3ae7403ec9000026","updated_at":"2014-01-06T21:27:40Z","title":"a
         new title","author":"Fyodor Dostoevsky","genre":"fiction"}'}
-    headers: {cache-control: 'max-age=0, private, must-revalidate', connection: close,
-      content-type: application/json; charset=utf-8, etag: '"686935fd6df32b8c170f3dc7a5b06845"',
-      server: thin 1.5.0 codename Knife, x-request-id: 3bdf0932122a322de09886bf9aac7d2d,
-      x-runtime: '0.037358', x-ua-compatible: IE=Edge}
+    headers: {}
     status: {code: 200, message: OK}
+version: 1

--- a/fixtures/update_documents.yaml
+++ b/fixtures/update_documents.yaml
@@ -1,18 +1,14 @@
-- request: !!python/object:vcr.request.Request
+interactions:
+- request:
     body: '{"documents": [{"fields": {"myfieldthathasnotbeencreated": "foobar"}, "external_id":
       "1"}, {"fields": {"title": "new title"}, "external_id": "2"}]}'
-    headers: !!python/object/apply:__builtin__.frozenset
-    - - !!python/tuple [User-Agent, Swiftype-Python/1.0.0]
-      - !!python/tuple [Content-Type, application/json]
-    host: localhost
+    headers:
+      Content-Type: [application/json]
+      User-Agent: [Swiftype-Python/1.0.0]
     method: PUT
-    path: /api/v1/engines/api-test/document_types/books/documents/bulk_update.json?auth_token=a-test-api-key
-    port: 3000
-    protocol: http
+    uri: http://localhost:3000/api/v1/engines/api-test/document_types/books/documents/bulk_update.json?auth_token=a-test-api-key
   response:
     body: {string: '[false,true]'}
-    headers: {cache-control: 'max-age=0, private, must-revalidate', connection: close,
-      content-type: application/json; charset=utf-8, etag: '"abd031b64f38bdc4bad852eccd2d978a"',
-      server: thin 1.5.0 codename Knife, x-request-id: 26aaf09dba59f3b28b2f64a923027d24,
-      x-runtime: '0.152484', x-ua-compatible: IE=Edge}
+    headers: {}
     status: {code: 200, message: OK}
+version: 1

--- a/fixtures/user.yaml
+++ b/fixtures/user.yaml
@@ -1,17 +1,13 @@
-- request: !!python/object:vcr.request.Request
+interactions:
+- request:
     body: ''
-    headers: !!python/object/apply:__builtin__.frozenset
-    - - !!python/tuple [User-Agent, Swiftype-Python/1.0.0]
-      - !!python/tuple [Content-Type, application/json]
-    host: localhost
+    headers:
+      Content-Type: [application/json]
+      User-Agent: [Swiftype-Python/1.0.0]
     method: GET
-    path: /api/v1/users/12345.json?client_secret=4441879b5e2a9c3271f5b1a4bc223b715f091e5ed20fe75d1352e1290c7a6dfb&auth_token=a-test-api-key&client_id=3e4fd842fc99aecb4dc50e5b88a186c1e206ddd516cdd336da3622c4afd7e2e9
-    port: 3000
-    protocol: http
+    uri: http://localhost:3000/api/v1/users/12345.json?client_secret=4441879b5e2a9c3271f5b1a4bc223b715f091e5ed20fe75d1352e1290c7a6dfb&auth_token=a-test-api-key&client_id=3e4fd842fc99aecb4dc50e5b88a186c1e206ddd516cdd336da3622c4afd7e2e9
   response:
     body: {string: '{"id":"12345","access_token":"ab37d7821853d6be1d7c451b449064ccf55300fdd5157baed48af53fd52b61f5"}'}
-    headers: {cache-control: 'max-age=0, private, must-revalidate', connection: close,
-      content-type: application/json; charset=utf-8, etag: '"28378b63dc4393c429edb345597939d5"',
-      server: thin 1.5.0 codename Knife, x-request-id: 2247f7e72009526040223e8b105c174a,
-      x-runtime: '0.024827', x-ua-compatible: IE=Edge}
+    headers: {}
     status: {code: 200, message: OK}
+version: 1

--- a/fixtures/users.yaml
+++ b/fixtures/users.yaml
@@ -1,17 +1,13 @@
-- request: !!python/object:vcr.request.Request
+interactions:
+- request:
     body: ''
-    headers: !!python/object/apply:__builtin__.frozenset
-    - - !!python/tuple [User-Agent, Swiftype-Python/1.0.0]
-      - !!python/tuple [Content-Type, application/json]
-    host: localhost
+    headers:
+      Content-Type: [application/json]
+      User-Agent: [Swiftype-Python/1.0.0]
     method: GET
-    path: /api/v1/users.json?client_secret=4441879b5e2a9c3271f5b1a4bc223b715f091e5ed20fe75d1352e1290c7a6dfb&auth_token=a-test-api-key&client_id=3e4fd842fc99aecb4dc50e5b88a186c1e206ddd516cdd336da3622c4afd7e2e9
-    port: 3000
-    protocol: http
+    uri: http://localhost:3000/api/v1/users.json?client_secret=4441879b5e2a9c3271f5b1a4bc223b715f091e5ed20fe75d1352e1290c7a6dfb&auth_token=a-test-api-key&client_id=3e4fd842fc99aecb4dc50e5b88a186c1e206ddd516cdd336da3622c4afd7e2e9
   response:
     body: {string: '[{"id":"12345","access_token":"6cf7fbd297f00a8e3863a0595f55ff7d141cbef2fcbe00159d0f7403649b384e"},{"id":"12346","access_token":"9937d7821853d6be1d7c451b449064ccf55300fdd5157baed48af53fd52b613c"}]'}
-    headers: {cache-control: 'max-age=0, private, must-revalidate', connection: close,
-      content-type: application/json; charset=utf-8, etag: '"8539c75e37dd05f0b7073aa733d859b4"',
-      server: thin 1.5.0 codename Knife, x-request-id: 542ac89c231fc6e166c6e47e0c47e702,
-      x-runtime: '0.022923', x-ua-compatible: IE=Edge}
+    headers: {}
     status: {code: 200, message: OK}
+version: 1

--- a/fixtures/users_pagination.yaml
+++ b/fixtures/users_pagination.yaml
@@ -1,17 +1,13 @@
-- request: !!python/object:vcr.request.Request
+interactions:
+- request:
     body: ''
-    headers: !!python/object/apply:__builtin__.frozenset
-    - - !!python/tuple [User-Agent, Swiftype-Python/1.0.0]
-      - !!python/tuple [Content-Type, application/json]
-    host: localhost
+    headers:
+      Content-Type: [application/json]
+      User-Agent: [Swiftype-Python/1.0.0]
     method: GET
-    path: /api/v1/users.json?client_secret=4441879b5e2a9c3271f5b1a4bc223b715f091e5ed20fe75d1352e1290c7a6dfb&auth_token=a-test-api-key&page=2&client_id=3e4fd842fc99aecb4dc50e5b88a186c1e206ddd516cdd336da3622c4afd7e2e9
-    port: 3000
-    protocol: http
+    uri: http://localhost:3000/api/v1/users.json?client_secret=4441879b5e2a9c3271f5b1a4bc223b715f091e5ed20fe75d1352e1290c7a6dfb&auth_token=a-test-api-key&page=2&client_id=3e4fd842fc99aecb4dc50e5b88a186c1e206ddd516cdd336da3622c4afd7e2e9
   response:
     body: {string: '[]'}
-    headers: {cache-control: 'max-age=0, private, must-revalidate', connection: close,
-      content-type: application/json; charset=utf-8, etag: '"d751713988987e9331980363e24189ce"',
-      server: thin 1.5.0 codename Knife, x-request-id: b1aad6d4e74543f75fc44ac778bbadd3,
-      x-runtime: '0.023024', x-ua-compatible: IE=Edge}
+    headers: {}
     status: {code: 200, message: OK}
+version: 1

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     author_email = 'team@swiftype.com',
     url = 'https://swiftype.com/',
     packages = find_packages(),
-    install_requires = ["anyjson", "future==0.16.0"],
+    install_requires = ["anyjson", "six"],
     test_suite='nose.collector',
     classifiers = [
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,7 @@
 
 from setuptools import setup, find_packages
 
-import os
-execfile(os.path.join('swiftype', 'version.py'))
+from swiftype.version import VERSION
 
 setup(
     name = 'swiftype',

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     author_email = 'team@swiftype.com',
     url = 'https://swiftype.com/',
     packages = find_packages(),
-    install_requires = ["anyjson"],
+    install_requires = ["anyjson", "future==0.16.0"],
     test_suite='nose.collector',
     classifiers = [
         'Intended Audience :: Developers',

--- a/swiftype/__init__.py
+++ b/swiftype/__init__.py
@@ -1,3 +1,3 @@
-from version import VERSION
+from .version import VERSION
 
 __version__ = VERSION

--- a/swiftype/swiftype.py
+++ b/swiftype/swiftype.py
@@ -87,22 +87,22 @@ class Client(object):
 
   def search(self, engine_id, query, options={}):
     query_string = {'q': query}
-    full_query = dict(list(query_string.items()) + list(options.items()))
+    full_query = dict(query_string, **options)
     return self.conn._get(self.__search_path(engine_id), data=full_query)
 
   def search_document_type(self, engine_id, document_type_id, query, options={}):
     query_string = {'q': query}
-    full_query = dict(list(query_string.items()) + list(options.items()))
+    full_query = dict(query_string, **options)
     return self.conn._get(self.__document_type_search_path(engine_id, document_type_id), data=full_query)
 
   def suggest(self, engine_id, query, options={}):
     query_string = {'q': query}
-    full_query = dict(list(query_string.items()) + list(options.items()))
+    full_query = dict(query_string, **options)
     return self.conn._get(self.__suggest_path(engine_id), data=full_query)
 
   def suggest_document_type(self, engine_id, document_type_id, query, options={}):
     query_string = {'q': query}
-    full_query = dict(list(query_string.items()) + list(options.items()))
+    full_query = dict(query_string, **options)
     return self.conn._get(self.__document_type_suggest_path(engine_id, document_type_id), data=full_query)
 
   def analytics_searches(self, engine_id, start_date=None, end_date=None):
@@ -144,7 +144,7 @@ class Client(object):
 
   def users(self, page=None, per_page=None):
     params = {'client_id': self.client_id, 'client_secret': self.client_secret}
-    return self.conn._get(self.__users_path(), dict(list(params.items()) + list(self.__pagination_params(page, per_page).items())))
+    return self.conn._get(self.__users_path(), dict(params, **self.__pagination_params(page, per_page)))
 
   def user(self, user_id):
     params = {'client_id': self.client_id, 'client_secret': self.client_secret}

--- a/swiftype/swiftype.py
+++ b/swiftype/swiftype.py
@@ -1,12 +1,21 @@
+from __future__ import unicode_literals
+
+from future.standard_library import install_aliases
+install_aliases()
+
 import anyjson
-import httplib
-import urllib
-import urlparse
 import base64
 import time
 import hashlib
+from urllib.parse import urlparse, urlunparse, urlencode
 
-from version import VERSION
+try:
+    # VCRpy only works when `httplib` is imported directly on Python 2.x
+    import httplib
+except ImportError:
+    import http.client as httplib
+
+from .version import VERSION
 
 USER_AGENT = 'Swiftype-Python/' + VERSION
 DEFAULT_API_HOST = 'api.swiftype.com'
@@ -80,41 +89,41 @@ class Client(object):
 
   def search(self, engine_id, query, options={}):
     query_string = {'q': query}
-    full_query = dict(query_string.items() + options.items())
+    full_query = dict(list(query_string.items()) + list(options.items()))
     return self.conn._get(self.__search_path(engine_id), data=full_query)
 
   def search_document_type(self, engine_id, document_type_id, query, options={}):
     query_string = {'q': query}
-    full_query = dict(query_string.items() + options.items())
+    full_query = dict(list(query_string.items()) + list(options.items()))
     return self.conn._get(self.__document_type_search_path(engine_id, document_type_id), data=full_query)
 
   def suggest(self, engine_id, query, options={}):
     query_string = {'q': query}
-    full_query = dict(query_string.items() + options.items())
+    full_query = dict(list(query_string.items()) + list(options.items()))
     return self.conn._get(self.__suggest_path(engine_id), data=full_query)
 
   def suggest_document_type(self, engine_id, document_type_id, query, options={}):
     query_string = {'q': query}
-    full_query = dict(query_string.items() + options.items())
+    full_query = dict(list(query_string.items()) + list(options.items()))
     return self.conn._get(self.__document_type_suggest_path(engine_id, document_type_id), data=full_query)
 
   def analytics_searches(self, engine_id, start_date=None, end_date=None):
-    params = dict((k,v) for k,v in {'start_date': start_date, 'end_date': end_date}.iteritems() if v is not None)
+    params = dict((k,v) for k,v in {'start_date': start_date, 'end_date': end_date}.items() if v is not None)
     return self.conn._get(self.__analytics_path(engine_id) + '/searches', params)
 
   def analytics_autoselects(self, engine_id, start_date=None, end_date=None):
-    params = dict((k,v) for k,v in {'start_date': start_date, 'end_date': end_date}.iteritems() if v is not None)
+    params = dict((k,v) for k,v in {'start_date': start_date, 'end_date': end_date}.items() if v is not None)
     return self.conn._get(self.__analytics_path(engine_id) + '/autoselects', params)
 
   def analytics_top_queries(self, engine_id, page=None, per_page=None):
     return self.conn._get(self.__analytics_path(engine_id) + '/top_queries', self.__pagination_params(page, per_page))
 
   def analytics_top_queries_in_range(self, engine_id, start_date=None, end_date=None):
-    params = dict((k,v) for k,v in {'start_date': start_date, 'end_date': end_date}.iteritems() if v is not None)
+    params = dict((k,v) for k,v in {'start_date': start_date, 'end_date': end_date}.items() if v is not None)
     return self.conn._get(self.__analytics_path(engine_id) + '/top_queries_in_range', params)
 
   def analytics_top_no_result_queries(self, engine_id, start_date=None, end_date=None):
-    params = dict((k,v) for k,v in {'start_date': start_date, 'end_date': end_date}.iteritems() if v is not None)
+    params = dict((k,v) for k,v in {'start_date': start_date, 'end_date': end_date}.items() if v is not None)
     return self.conn._get(self.__analytics_path(engine_id) + '/top_no_result_queries_in_range', params)
 
   def domains(self, engine_id):
@@ -137,7 +146,7 @@ class Client(object):
 
   def users(self, page=None, per_page=None):
     params = {'client_id': self.client_id, 'client_secret': self.client_secret}
-    return self.conn._get(self.__users_path(), dict(params.items() + self.__pagination_params(page, per_page).items()))
+    return self.conn._get(self.__users_path(), dict(list(params.items()) + list(self.__pagination_params(page, per_page).items())))
 
   def user(self, user_id):
     params = {'client_id': self.client_id, 'client_secret': self.client_secret}
@@ -150,10 +159,12 @@ class Client(object):
   def sso_url(self, user_id):
     timestamp = self._get_timestamp()
     params = {'user_id': user_id, 'client_id': self.client_id, 'timestamp': timestamp, 'token': self._sso_token(user_id, timestamp)}
-    return urlparse.urlunparse(('https', 'swiftype.com', '/sso', '', urllib.urlencode(params), ''))
+    return urlunparse(('https', 'swiftype.com', '/sso', '', urlencode(params), ''))
 
   def _sso_token(self, user_id, timestamp):
-    return hashlib.sha1('%s:%s:%s' % (user_id, self.client_secret, timestamp)).hexdigest()
+    return hashlib.sha1((
+        '%s:%s:%s' % (user_id, self.client_secret, timestamp)
+    ).encode('utf-8')).hexdigest()
 
   def _get_timestamp(self):
     return int(time.time())
@@ -175,7 +186,7 @@ class Client(object):
   def __user_path(self, user_id): return 'users/%s' % (user_id)
 
   def __pagination_params(self, page, per_page):
-    return dict((k,v) for k,v in {'page': page, 'per_page': per_page}.iteritems() if v is not None)
+    return dict((k,v) for k,v in {'page': page, 'per_page': per_page}.items() if v is not None)
 
 class HttpException(Exception):
     def __init__(self, status, msg):
@@ -224,7 +235,7 @@ class Connection(object):
       raise Unauthorized('Authorization required.')
 
     full_path = self.__base_path + path + '.json'
-    query = urllib.urlencode(params, True)
+    query = urlencode(params, True)
     if query:
       full_path += '?' + query
 
@@ -235,11 +246,11 @@ class Connection(object):
 
     response = connection.getresponse()
     response.body = response.read()
-    if (response.status / 100 == 2):
+    if (response.status // 100 == 2):
         if response.body:
             try:
-                response.body = anyjson.deserialize(response.body)
-            except ValueError, e:
+                response.body = anyjson.deserialize(response.body.decode('utf-8'))
+            except ValueError as e:
                 raise InvalidResponseFromServer('The JSON response could not be parsed: %s.\n%s' % (e, response.body))
             ret = {'status': response.status, 'body':response.body }
         else:

--- a/swiftype/swiftype.py
+++ b/swiftype/swiftype.py
@@ -1,13 +1,11 @@
 from __future__ import unicode_literals
 
-from future.standard_library import install_aliases
-install_aliases()
-
-import anyjson
 import base64
 import time
 import hashlib
-from urllib.parse import urlparse, urlunparse, urlencode
+
+import anyjson
+from six.moves.urllib_parse import urlunparse, urlencode
 
 try:
     # VCRpy only works when `httplib` is imported directly on Python 2.x

--- a/swiftype/swiftype.py
+++ b/swiftype/swiftype.py
@@ -218,10 +218,9 @@ class Connection(object):
     headers = {}
     headers['User-Agent'] = USER_AGENT
     headers['Content-Type'] = 'application/json'
-
     if self.__username is not None and self.__password is not None:
       credentials = "%s:%s" % (self.__username, self.__password)
-      base64_credentials = base64.encodestring(credentials)
+      base64_credentials = base64.encodestring(credentials.encode('utf-8')).decode()
       authorization = "Basic %s" % base64_credentials[:-1]
       headers['Authorization'] = authorization
     elif self.__access_token is not None and self.__api_key is None:

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,4 @@
-nose==1.3.0
-vcrpy==0.5.0
+nose==1.3.7
+vcrpy==1.11.1
 mock>=1.0.1
 unittest2

--- a/tests/test_swiftype.py
+++ b/tests/test_swiftype.py
@@ -2,7 +2,7 @@ from swiftype import swiftype
 import os
 import time
 import unittest2 as unittest
-from urllib.parse import urlparse, parse_qs
+from six.moves.urllib_parse import urlparse, parse_qs
 import vcr
 from mock import Mock
 

--- a/tests/test_swiftype.py
+++ b/tests/test_swiftype.py
@@ -287,6 +287,23 @@ class TestClientFunctions(unittest.TestCase):
         name = name if name else self.__time_name()
         return
 
+
+class TestClientUsernameAndPassword(unittest.TestCase):
+
+    def setUp(self):
+        self.client = swiftype.Client(
+            username='some_user',
+            password='some_pasword',
+            host='localhost:3000'
+        )
+
+    def test_engine_create(self):
+        with vcr.use_cassette('fixtures/engine_create.yaml'):
+            engine = 'myengine'
+            slug = self.client.create_engine(engine)['body']['slug']
+            self.assertEqual(slug, engine)
+
+
 class TestPlatformUsers(unittest.TestCase):
 
     def setUp(self):

--- a/tests/test_swiftype.py
+++ b/tests/test_swiftype.py
@@ -2,6 +2,7 @@ from swiftype import swiftype
 import os
 import time
 import unittest2 as unittest
+from urllib.parse import urlparse, parse_qs
 import vcr
 from mock import Mock
 
@@ -269,14 +270,14 @@ class TestClientFunctions(unittest.TestCase):
     def __is_expected_result(self, request, status_code, expected_values, *args):
         response = request(*args)
         self.assertEqual(response['status'], status_code)
-        for k,v in expected_values.iteritems():
+        for k,v in expected_values.items():
             self.assertEqual(response['body'][k], v)
 
     def __is_expected_collection(self, request, status_code, collection_length, expected_values, *args):
         response = request(*args)
         self.assertEqual(response['status'], status_code)
         self.assertEqual(len(response['body']), collection_length)
-        for k,v in expected_values.iteritems():
+        for k,v in expected_values.items():
             self.assertEqual(len([item for item in response['body'] if item[k] == v]), 1)
 
     def __time_name(self):
@@ -331,7 +332,15 @@ class TestPlatformUsers(unittest.TestCase):
         self.client._get_timestamp = Mock(return_value=1379382520)
         user_id = '5064a7de2ed960e715000276'
         url = self.client.sso_url(user_id)
-        self.assertEqual(url, 'https://swiftype.com/sso?timestamp=1379382520&token=81033d182ad51f231cc9cda9fb24f2298a411437&user_id=5064a7de2ed960e715000276&client_id=3e4fd842fc99aecb4dc50e5b88a186c1e206ddd516cdd336da3622c4afd7e2e9')
+        self.assertEqual(
+            parse_qs(urlparse(url).query),
+            {
+                'user_id': ['5064a7de2ed960e715000276'],
+                'client_id': ['3e4fd842fc99aecb4dc50e5b88a186c1e206ddd516cdd336da3622c4afd7e2e9'],
+                'token': ['81033d182ad51f231cc9cda9fb24f2298a411437'],
+                'timestamp': ['1379382520'],
+            },
+        )
 
 class TestPlatformResources(unittest.TestCase):
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+envlist = py27,py36,pypy
+skip_missing_interpreters = true
+
+[testenv]
+deps = -rtest_requirements.txt
+
+commands = python setup.py test


### PR DESCRIPTION
This PR updates the library to be compatible with both Python 2 and 3. It uses the `future` library to achieve that, though there weren't too many changes that were required.

The biggest change is that the `VCRpy` package was updated to the latest version, which necessitated migrating the cassettes to the new format. Tests now pass in all supported version of Python, though!